### PR TITLE
Renamed store classes to keep consistency with other libs

### DIFF
--- a/android-lib/android-lib.iml
+++ b/android-lib/android-lib.iml
@@ -12,10 +12,7 @@
         <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
-        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugAndroidTest" />
-        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileDebugAndroidTestSources" />
         <afterSyncTasks>
-          <task>generateDebugAndroidTestSources</task>
           <task>generateDebugSources</task>
         </afterSyncTasks>
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
@@ -29,7 +26,7 @@
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
-    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/androidTest/debug" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/debug" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/debug" isTestSource="false" generated="true" />
@@ -53,6 +50,15 @@
       <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
@@ -60,6 +66,15 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
@@ -67,7 +82,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/build/docs" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/annotations" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
@@ -81,7 +96,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/multidex-instrumentation/1.0.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/multidex/1.0.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.0.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.github.KeepSafe/ReLinker/1.1/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.getkeepsafe.relinker/relinker/1.2.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.android.gms/play-services-ads/8.4.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.android.gms/play-services-analytics/8.4.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.android.gms/play-services-appindexing/8.4.0/jars" />
@@ -107,14 +122,15 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.android.gms/play-services-wallet/8.4.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.android.gms/play-services-wearable/8.4.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.android.gms/play-services/8.4.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/io.realm/realm-android-library/0.88.0/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/io.realm/realm-android-library/1.1.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
-      <excludeFolder url="file://$MODULE_DIR$/build/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/reports" />
       <excludeFolder url="file://$MODULE_DIR$/build/test-results" />
@@ -123,33 +139,35 @@
     <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" exported="" name="play-services-base-8.4.0" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="httpclient-4.0.1" level="project" />
     <orderEntry type="library" exported="" name="rxjava-1.1.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="objenesis-2.1" level="project" />
-    <orderEntry type="library" exported="" name="play-services-identity-8.4.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="hamcrest-library-1.3" level="project" />
+    <orderEntry type="library" exported="" name="play-services-identity-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="google-http-client-android-1.19.0" level="project" />
-    <orderEntry type="library" exported="" name="google-http-client-jackson2-1.19.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="exposed-instrumentation-api-publish-0.4.1" level="project" />
+    <orderEntry type="library" exported="" name="google-http-client-jackson2-1.19.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-auth-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-location-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-drive-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-safetynet-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="jsr305-1.3.9" level="project" />
-    <orderEntry type="library" exported="" name="ReLinker-1.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="commons-codec-1.3" level="project" />
     <orderEntry type="library" exported="" name="google-api-client-1.19.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="junit-4.12" level="project" />
     <orderEntry type="library" exported="" name="google-http-client-1.19.0" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="httpcore-4.0.1" level="project" />
     <orderEntry type="library" exported="" name="ant-launcher-1.8.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-appstate-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-gcm-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-plus-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-analytics-8.4.0" level="project" />
-    <orderEntry type="library" exported="" name="play-services-measurement-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="gson-2.4" level="project" />
+    <orderEntry type="library" exported="" name="play-services-measurement-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="google-oauth-client-1.19.0" level="project" />
-    <orderEntry type="library" exported="" name="realm-annotations-0.88.0" level="project" />
     <orderEntry type="library" exported="" name="jackson-core-2.1.3" level="project" />
     <orderEntry type="library" exported="" name="multidex-1.0.1" level="project" />
+    <orderEntry type="library" exported="" name="realm-annotations-1.1.0" level="project" />
     <orderEntry type="library" exported="" name="google-http-client-gson-1.19.0" level="project" />
     <orderEntry type="library" exported="" name="google-api-client-android-1.19.0" level="project" />
     <orderEntry type="library" exported="" name="google-http-client-jackson-1.19.0" level="project" />
@@ -160,28 +178,30 @@
     <orderEntry type="library" exported="" name="ant-1.8.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="rules-0.4.1" level="project" />
     <orderEntry type="library" exported="" name="play-services-vision-8.4.0" level="project" />
-    <orderEntry type="library" exported="" name="play-services-wearable-8.4.0" level="project" />
+    <orderEntry type="library" exported="" name="realm-android-library-1.1.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="mockito-core-1.10.19" level="project" />
+    <orderEntry type="library" exported="" name="play-services-wearable-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-appindexing-8.4.0" level="project" />
-    <orderEntry type="library" exported="" name="play-services-nearby-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="dexmaker-1.2" level="project" />
+    <orderEntry type="library" exported="" name="play-services-nearby-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-8.4.0" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="commons-logging-1.1.1" level="project" />
     <orderEntry type="library" exported="" name="play-services-basement-8.4.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="runner-0.4.1" level="project" />
     <orderEntry type="library" exported="" name="play-services-maps-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-appinvite-8.4.0" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="hamcrest-core-1.3" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="dexmaker-mockito-1.2" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="hamcrest-core-1.3" level="project" />
+    <orderEntry type="library" exported="" name="relinker-1.2.1" level="project" />
     <orderEntry type="library" exported="" name="play-services-ads-8.4.0" level="project" />
-    <orderEntry type="library" exported="" name="play-services-games-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-fitness-8.4.0" level="project" />
+    <orderEntry type="library" exported="" name="play-services-games-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="mediarouter-v7-23.0.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-wallet-8.4.0" level="project" />
-    <orderEntry type="library" exported="" name="realm-android-library-0.88.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-panorama-8.4.0" level="project" />
     <orderEntry type="library" exported="" name="appcompat-v7-23.0.0" level="project" />
-    <orderEntry type="library" exported="" name="support-annotations-23.0.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="multidex-instrumentation-1.0.1" level="project" />
+    <orderEntry type="library" exported="" name="support-annotations-23.0.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-cast-8.4.0" level="project" />
     <orderEntry type="module" module-name="java-api-core" exported="" />
   </component>

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/FileStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/FileStoreTest.java
@@ -5,8 +5,8 @@ import android.support.test.runner.AndroidJUnit4;
 import android.test.suitebuilder.annotation.SmallTest;
 
 import com.kinvey.android.Client;
-import com.kinvey.android.store.AsyncFileStore;
-import com.kinvey.android.store.AsyncUserStore;
+import com.kinvey.android.store.FileStore;
+import com.kinvey.android.store.UserStore;
 import com.kinvey.java.core.DownloaderProgressListener;
 import com.kinvey.java.core.KinveyClientCallback;
 import com.kinvey.java.core.MediaHttpDownloader;
@@ -14,9 +14,8 @@ import com.kinvey.java.core.MediaHttpUploader;
 import com.kinvey.java.core.UploaderProgressListener;
 import com.kinvey.java.dto.User;
 import com.kinvey.java.model.FileMetaData;
-import com.kinvey.java.store.FileStore;
+import com.kinvey.java.store.BaseFileStore;
 import com.kinvey.java.store.StoreType;
-import com.kinvey.java.store.UserStoreRequestManager;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -44,13 +43,13 @@ public class FileStoreTest {
         Client.Builder builder = new Client.Builder(InstrumentationRegistry.getContext());
         client = builder.build();
         if (!client.isUserLoggedIn()) {
-            AsyncUserStore.login(client, User.class);
+            UserStore.login(client, User.class);
         }
     }
     @Test
     public void testUpload() throws IOException {
 
-        FileStore fileStore = client.getFileStore(StoreType.CACHE);
+        BaseFileStore fileStore = client.getFileStore(StoreType.CACHE);
 
         File test = new File(client.getContext().getFilesDir(), "test.xml");
         if (!test.exists()){
@@ -84,7 +83,7 @@ public class FileStoreTest {
     public void testUploadAndGet() throws IOException {
 
         for (StoreType storeType : StoreType.values()){
-            FileStore fileStore = client.getFileStore(storeType);
+            BaseFileStore fileStore = client.getFileStore(storeType);
             fileStore.setStoreType(storeType);
 
             File test = new File(client.getContext().getFilesDir(), "test"+storeType.toString()+".xml");
@@ -150,7 +149,7 @@ public class FileStoreTest {
 
     @Test
     public void asyncCallsShouldNotFail() throws IOException {
-        AsyncFileStore fileStore = client.getFileStore(StoreType.SYNC);
+        FileStore fileStore = client.getFileStore(StoreType.SYNC);
 
         File test = new File(client.getContext().getFilesDir(), "test.xml");
         if (!test.exists()){

--- a/android-lib/src/main/java/com/kinvey/android/AsyncPullRequest.java
+++ b/android-lib/src/main/java/com/kinvey/android/AsyncPullRequest.java
@@ -19,8 +19,7 @@ package com.kinvey.android;
 import com.kinvey.android.sync.KinveyPullCallback;
 import com.kinvey.android.sync.KinveyPullResponse;
 import com.kinvey.java.Query;
-import com.kinvey.java.dto.User;
-import com.kinvey.java.store.DataStore;
+import com.kinvey.java.store.BaseDataStore;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -29,7 +28,7 @@ import java.lang.reflect.InvocationTargetException;
  * Class represents internal implementation of Async pull request that is used to create pull
  */
 public class AsyncPullRequest<T> extends AsyncClientRequest<KinveyPullResponse<T>> {
-    private final DataStore store;
+    private final BaseDataStore store;
     private Query query;
 
     /**
@@ -38,7 +37,7 @@ public class AsyncPullRequest<T> extends AsyncClientRequest<KinveyPullResponse<T
      * @param store Kinvey data store instance to be used to execute network requests
      * @param callback async callbacks to be invoked when job is done
      */
-    public AsyncPullRequest(DataStore store,
+    public AsyncPullRequest(BaseDataStore store,
                             Query query,
                             KinveyPullCallback<T> callback){
         super(callback);

--- a/android-lib/src/main/java/com/kinvey/android/Client.java
+++ b/android-lib/src/main/java/com/kinvey/android/Client.java
@@ -17,11 +17,6 @@
 package com.kinvey.android;
 
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-
 import android.content.Context;
 import android.os.AsyncTask;
 
@@ -40,29 +35,26 @@ import com.kinvey.android.cache.RealmCacheManager;
 import com.kinvey.android.callback.KinveyClientBuilderCallback;
 import com.kinvey.android.callback.KinveyPingCallback;
 import com.kinvey.android.callback.KinveyUserCallback;
-import com.kinvey.android.network.AndroidNetworkManager;
-import com.kinvey.android.network.AsyncLinkedNetworkManager;
 import com.kinvey.android.push.AbstractPush;
 import com.kinvey.android.push.GCMPush;
-import com.kinvey.android.store.AsyncDataStore;
-import com.kinvey.android.store.AsyncFileStore;
-import com.kinvey.android.store.AsyncLinkedDataStore;
-import com.kinvey.android.store.AsyncUserStore;
+import com.kinvey.android.store.FileStore;
 import com.kinvey.java.AbstractClient;
 import com.kinvey.java.ClientExtension;
 import com.kinvey.java.Logger;
-import com.kinvey.java.LinkedResources.LinkedGenericJson;
 import com.kinvey.java.auth.ClientUser;
 import com.kinvey.java.auth.Credential;
 import com.kinvey.java.auth.CredentialManager;
 import com.kinvey.java.auth.CredentialStore;
 import com.kinvey.java.cache.ICacheManager;
-import com.kinvey.java.core.KinveyClientCallback;
 import com.kinvey.java.core.KinveyClientRequestInitializer;
 import com.kinvey.java.dto.User;
 import com.kinvey.java.network.NetworkFileManager;
 import com.kinvey.java.store.StoreType;
-import com.kinvey.java.store.UserStore;
+import com.kinvey.java.store.BaseUserStore;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * This class is an implementation of a {@link com.kinvey.java.AbstractClient} with default settings for the Android operating
@@ -97,9 +89,9 @@ public class Client extends AbstractClient {
 
     private Context context = null;
 
-    private ConcurrentHashMap<String, AsyncDataStore> appDataInstanceCache;
-    private ConcurrentHashMap<String, AsyncLinkedDataStore> linkedDataInstanceCache;
-    private ConcurrentHashMap<String, AsyncCustomEndpoints> customeEndpointsCache;
+//    private ConcurrentHashMap<String, DataStore> appDataInstanceCache;
+//    private ConcurrentHashMap<String, LinkedDataStore> linkedDataInstanceCache;
+//    private ConcurrentHashMap<String, AsyncCustomEndpoints> customeEndpointsCache;
     private AsyncCustomEndpoints customEndpoints;
     private AbstractPush pushProvider;
     private AsyncUserDiscovery userDiscovery;
@@ -145,73 +137,6 @@ public class Client extends AbstractClient {
     public static Client sharedInstance(){
     	return _sharedInstance;
     }
-
-
-    /**
-     * DataStore factory method
-     * <p>
-     * Returns an instance of {@link AsyncDataStore} for the supplied collection.  A new instance is created for each collection, but
-     * only one instance of {@link AndroidNetworkManager} is created per collection.  The method is Generic and takes an instance of a
-     * {@link com.google.api.client.json.GenericJson} entity type that is used for fetching/saving of {@link com.kinvey.java.store.DataStore}.
-     * </p>
-     * <p>
-     * This method is thread-safe.
-     * </p>
-     * <p>
-     *     Sample Usage:
-     * <pre>
-     * {@code
-        DataStore<myEntity> myAppData = kinveyClient.appData("entityCollection", myEntity.class);
-     }
-     * </pre>
-     * </p>
-     *
-     * @param collectionName The name of the collection
-     * @param myClass The class that defines the entity of type {@link com.google.api.client.json.GenericJson} used
-     *                for saving and fetching of data
-     * @param <T> Generic of type {@link com.google.api.client.json.GenericJson} of same type as myClass
-     * @return Instance of {@link com.kinvey.java.store.DataStore} for getStoreTypethe defined collection
-     */
-    public <T extends GenericJson> AsyncDataStore<T> dataStore(String collectionName, Class<T> myClass, StoreType storeType) {
-        Preconditions.checkNotNull(collectionName, "collectionName cannot be null.");
-        Preconditions.checkNotNull(storeType, "storeType cannot be null.");
-        Preconditions.checkArgument(isInitialize(), "client must be initialized.");
-        return new AsyncDataStore(collectionName, myClass, this, storeType);
-    }
-
-    /**
-     * LinkedDataStore factory method
-     * <p>
-     * Returns an instance of {@link AsyncLinkedNetworkManager} for the supplied collection.  A new instance is created for each collection, but
-     * only one instance of LinkedNetworkManager is created per collection.  The method is Generic and takes an instance of a
-     * {@link LinkedGenericJson} entity type that is used for fetching/saving of {@link AsyncLinkedNetworkManager}.
-     * </p>
-     * <p>
-     * This method is thread-safe.
-     * </p>
-     * <p>
-     *     Sample Usage:
-     * <pre>
-     * {@code
-    LinkedDataStore<myEntity> myAppData = kinveyClient.linkedData("entityCollection", myEntity.class);
-    }
-     * </pre>
-     * </p>
-     *
-     * @param collectionName The name of the collection
-     * @param myClass The class that defines the entity of type {@link LinkedGenericJson} used for saving and fetching of data
-     * @param <T> Generic of type {@link com.google.api.client.json.GenericJson} of same type as myClass
-     * @param storeType indicate what kind of store will we use
-     * @return Instance of {@link AsyncLinkedNetworkManager} for the defined collection
-     */
-    public <T extends LinkedGenericJson> AsyncLinkedDataStore<T> linkedData(String collectionName, Class<T> myClass, StoreType storeType) {
-        Preconditions.checkArgument(isInitialize(), "client must be initialized.");
-        Preconditions.checkNotNull(collectionName, "collectionName cannot be null.");
-        Preconditions.checkNotNull(storeType, "storeType cannot be null.");
-        return new AsyncLinkedDataStore(this, collectionName, myClass,
-                storeType);
-    }
-
 
     @Override
     public void performLockDown() {
@@ -824,7 +749,7 @@ public class Client extends AbstractClient {
         private void loginWithCredential(final Client client, Credential credential) {
             getKinveyClientRequestInitializer().setCredential(credential);
             try {
-                UserStore.login(credential, client);
+                BaseUserStore.login(credential, client);
             } catch (IOException ex) {
             	Logger.ERROR("Could not retrieve user Credentials");
             }
@@ -835,13 +760,13 @@ public class Client extends AbstractClient {
                 protected User doInBackground(Void... voids) {
                     User result = null;
                     try{
-                        result = UserStore.convenience(client);
+                        result = BaseUserStore.convenience(client);
                         client.setUser(result);
                     }catch (Exception error){
                         this.error = error;
                         if ((error instanceof HttpResponseException)) {
                             try {
-                                UserStore.logout(client);
+                                BaseUserStore.logout(client);
                             } catch (IOException e) {
                                 e.printStackTrace();
                             }
@@ -901,8 +826,8 @@ public class Client extends AbstractClient {
     }
 
     @Override
-    public AsyncFileStore getFileStore(StoreType storeType) {
-        return new AsyncFileStore(new NetworkFileManager(this),
+    public FileStore getFileStore(StoreType storeType) {
+        return new FileStore(new NetworkFileManager(this),
                     getCacheManager(), 60*60*1000L, storeType, getFileCacheFolder()
                 );
     }

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCacheManager.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCacheManager.java
@@ -108,7 +108,7 @@ public class RealmCacheManager implements ICacheManager {
                 if (!collectionItemClass.isAssignableFrom(cache.getCollectionItemClass()) &&
                         !cache.getCollectionItemClass().isAssignableFrom(collectionItemClass)){
                     throw new KinveyException("Class implementation for collection have been changed during runtime",
-                            "Please review the DataStore usage, parameter should remain the same for same collection",
+                            "Please review the BaseDataStore usage, parameter should remain the same for same collection",
                             "Seems like you have used different classes for same colledtion in AsyncAppDataCreaton");
                 }
                 //create new instance because ttl values differs for diffetent store types and

--- a/android-lib/src/main/java/com/kinvey/android/push/GCMPush.java
+++ b/android-lib/src/main/java/com/kinvey/android/push/GCMPush.java
@@ -33,13 +33,11 @@ import com.google.api.client.util.Key;
 import com.kinvey.android.AsyncClientRequest;
 import com.kinvey.android.Client;
 import com.kinvey.android.callback.KinveyUserCallback;
-import com.kinvey.android.store.AsyncUserStore;
+import com.kinvey.android.store.UserStore;
 import com.kinvey.java.KinveyException;
 import com.kinvey.java.Logger;
 import com.kinvey.java.core.KinveyClientCallback;
 import com.kinvey.java.dto.User;
-import com.kinvey.java.store.UserStore;
-import com.kinvey.java.store.UserStoreRequestManager;
 
 
 /**
@@ -140,7 +138,7 @@ public class GCMPush extends AbstractPush {
             client.push().enablePushViaRest(new KinveyClientCallback() {
                 @Override
                 public void onSuccess(Object result) {
-                	AsyncUserStore.retrieve(client, new KinveyUserCallback<User>() {
+                	UserStore.retrieve(client, new KinveyUserCallback<User>() {
 						
 						@Override
 						public void onSuccess(User result) {

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.java
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.java
@@ -35,12 +35,10 @@ import com.kinvey.java.AbstractClient;
 import com.kinvey.java.Logger;
 import com.kinvey.java.Query;
 import com.kinvey.java.core.KinveyClientCallback;
-import com.kinvey.java.dto.User;
 import com.kinvey.java.network.NetworkManager;
 import com.kinvey.java.query.MongoQueryFilter;
-import com.kinvey.java.store.DataStore;
+import com.kinvey.java.store.BaseDataStore;
 import com.kinvey.java.store.StoreType;
-import com.kinvey.java.store.UserStore;
 import com.kinvey.java.sync.SyncManager;
 
 import java.io.IOException;
@@ -54,7 +52,7 @@ import java.util.Map;
  * Wraps the {@link NetworkManager} public methods in asynchronous functionality using native Android AsyncTask.
  * <p/>
  * <p>
- * This functionality can be accessed through the {@link Client#dataStore convenience method.  DataStore
+ * This functionality can be accessed through the {@link Client#dataStore convenience method.  BaseDataStore
  * gets and saves and sync entities that extend {@link com.google.api.client.json.GenericJson}.  A class that extends GenericJson
  * can map class members to KinveyCollection properties using {@link com.google.api.client.util.Key} attributes.  For example,
  * the following will map a string "city" to a Kinvey collection attributed named "city":
@@ -100,7 +98,7 @@ import java.util.Map;
  * @version $Id: $
  * @since 2.0
  */
-public class AsyncDataStore<T extends GenericJson> extends DataStore<T> {
+public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
 
 
     //Every AbstractClient Request wrapper provided by the core NetworkManager gets a KEY here.
@@ -116,9 +114,6 @@ public class AsyncDataStore<T extends GenericJson> extends DataStore<T> {
     private static final String KEY_DELETE_BY_IDS = "KEY_DELETE_BY_IDS";
 
     private static final String KEY_PURGE = "KEY_PURGE";
-
-
-
 
 
     /*private static final String KEY_GET_BY_ID_WITH_REFERENCES = "KEY_GET_BY_ID_WITH_REFERENCES";
@@ -142,7 +137,7 @@ public class AsyncDataStore<T extends GenericJson> extends DataStore<T> {
      * @param collectionName Name of the appData collection
      * @param myClass        Class Type to marshall data between.
      */
-    public AsyncDataStore(String collectionName, Class myClass, AbstractClient client, StoreType storeType) {
+    protected DataStore(String collectionName, Class myClass, AbstractClient client, StoreType storeType) {
         super(client, collectionName, myClass, storeType);
         loadMethodMap();
     }
@@ -153,24 +148,31 @@ public class AsyncDataStore<T extends GenericJson> extends DataStore<T> {
      * @param collectionName Name of the appData collection
      * @param myClass        Class Type to marshall data between.
      */
-    public AsyncDataStore(String collectionName, Class myClass, AbstractClient client, StoreType storeType, NetworkManager<T> networkManager) {
+    public DataStore(String collectionName, Class myClass, AbstractClient client, StoreType storeType, NetworkManager<T> networkManager) {
         super(client, collectionName, myClass, storeType, networkManager);
         loadMethodMap();
+    }
+
+    public static <T extends GenericJson> DataStore<T> collection(String collectionName, Class<T> myClass, StoreType storeType, AbstractClient client) {
+        Preconditions.checkNotNull(collectionName, "collectionName cannot be null.");
+        Preconditions.checkNotNull(storeType, "storeType cannot be null.");
+        Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
+        return new DataStore(collectionName, myClass, client, storeType);
     }
 
     private void loadMethodMap() {
         Map<String, Method> tempMap = new HashMap<String, Method>();
         try {
-            tempMap.put(KEY_GET_BY_ID, DataStore.class.getMethod("find", String.class));
-            tempMap.put(KEY_GET_BY_QUERY, DataStore.class.getMethod("find", Query.class));
-            tempMap.put(KEY_GET_ALL, DataStore.class.getMethod("find"));
-            tempMap.put(KEY_GET_BY_IDS, DataStore.class.getMethod("find", Iterable.class));
+            tempMap.put(KEY_GET_BY_ID, BaseDataStore.class.getMethod("find", String.class));
+            tempMap.put(KEY_GET_BY_QUERY, BaseDataStore.class.getMethod("find", Query.class));
+            tempMap.put(KEY_GET_ALL, BaseDataStore.class.getMethod("find"));
+            tempMap.put(KEY_GET_BY_IDS, BaseDataStore.class.getMethod("find", Iterable.class));
 
-            tempMap.put(KEY_DELETE_BY_ID, DataStore.class.getMethod("delete", String.class));
-            tempMap.put(KEY_DELETE_BY_QUERY, DataStore.class.getMethod("delete", Query.class));
-            tempMap.put(KEY_DELETE_BY_IDS, DataStore.class.getMethod("delete", Iterable.class));
+            tempMap.put(KEY_DELETE_BY_ID, BaseDataStore.class.getMethod("delete", String.class));
+            tempMap.put(KEY_DELETE_BY_QUERY, BaseDataStore.class.getMethod("delete", Query.class));
+            tempMap.put(KEY_DELETE_BY_IDS, BaseDataStore.class.getMethod("delete", Iterable.class));
 
-            tempMap.put(KEY_PURGE, DataStore.class.getMethod("purge"));
+            tempMap.put(KEY_PURGE, BaseDataStore.class.getMethod("purge"));
 
 
             /*tempMap.put(KEY_GET_BY_ID_WITH_REFERENCES, NetworkManager.class.getMethod("getEntityBlocking", new Class[]{String.class, String[].class, int.class, boolean.class}));
@@ -197,7 +199,7 @@ public class AsyncDataStore<T extends GenericJson> extends DataStore<T> {
      * Sample Usage:
      * <pre>
      * {@code
-     *     AsyncDataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class).get("123",
+     *     DataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class).get("123",
      *             new KinveyClientCallback<EventEntity> {
      *         public void onFailure(Throwable t) { ... }
      *         public void onSuccess(EventEntity entity) { ... }
@@ -226,7 +228,7 @@ public class AsyncDataStore<T extends GenericJson> extends DataStore<T> {
      * Sample Usage:
      * <pre>
      * {@code
-     *     AsyncDataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class);
+     *     DataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class);
      *     myAppData.get(new String[]{"189472023", "10193583"}, new KinveyListCallback<EventEntity> {
      *         public void onFailure(Throwable t) { ... }
      *         public void onSuccess(EventEntity[] entities) { ... }
@@ -257,7 +259,7 @@ public class AsyncDataStore<T extends GenericJson> extends DataStore<T> {
      * Sample Usage:
      * <pre>
      * {@code
-     *     AsyncDataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class);
+     *     DataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class);
      *     Query myQuery = new Query();
      *     myQuery.equals("age",21);
      *     myAppData.get(myQuery, new KinveyListCallback<EventEntity> {
@@ -288,7 +290,7 @@ public class AsyncDataStore<T extends GenericJson> extends DataStore<T> {
      * Sample Usage:
      * <pre>
      * {@code
-     *     AsyncDataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class);
+     *     DataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class);
      *     myAppData.get(new KinveyListCallback<EventEntity> {
      *         public void onFailure(Throwable t) { ... }
      *         public void onSuccess(EventEntity[] entities) { ... }
@@ -316,7 +318,7 @@ public class AsyncDataStore<T extends GenericJson> extends DataStore<T> {
      * Sample Usage:
      * <pre>
      * {@code
-     *     AsyncDataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class);
+     *     DataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class);
      *     myAppData.save(entityID, new KinveyClientCallback<EventEntity> {
      *         public void onFailure(Throwable t) { ... }
      *         public void onSuccess(EventEntity[] entities) { ... }
@@ -347,7 +349,7 @@ public class AsyncDataStore<T extends GenericJson> extends DataStore<T> {
      * Sample Usage:
      * <pre>
      * {@code
-     *     AsyncDataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class);
+     *     DataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class);
      *     myAppData.delete(myQuery, new KinveyDeleteCallback {
      *         public void onFailure(Throwable t) { ... }
      *         public void onSuccess(EventEntity[] entities) { ... }
@@ -374,7 +376,7 @@ public class AsyncDataStore<T extends GenericJson> extends DataStore<T> {
      * Sample Usage:
      * <pre>
      * {@code
-     *     AsyncDataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class);
+     *     DataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class);
      *     List<String> ids = ...
      *     myAppData.delete(ids, new KinveyDeleteCallback {
      *         public void onFailure(Throwable t) { ... }
@@ -401,7 +403,7 @@ public class AsyncDataStore<T extends GenericJson> extends DataStore<T> {
      * Sample Usage:
      * <pre>
      * {@code
-     *     AsyncDataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class);
+     *     DataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class);
      *     Query myQuery = new Query();
      *     myQuery.equals("age",21);
      *     myAppData.delete(myQuery, new KinveyDeleteCallback {
@@ -464,7 +466,7 @@ public class AsyncDataStore<T extends GenericJson> extends DataStore<T> {
      * Sample Usage:
      * <pre>
      * {@code
-     *     AsyncDataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class);
+     *     DataStore<EventEntity> myAppData = kinveyClient.appData("myCollection", EventEntity.class);
      *     Query myQuery = new Query();
      *     myQuery.equals("age",21);
      *     myAppData.sync(myQuery, new KinveySyncCallback {
@@ -492,7 +494,7 @@ public class AsyncDataStore<T extends GenericJson> extends DataStore<T> {
             public void onSuccess(final KinveyPushResponse pushResult) {
                 callback.onPushSuccess(pushResult);
                 callback.onPullStarted();
-                AsyncDataStore.this.pull(query, new KinveyPullCallback<T>() {
+                DataStore.this.pull(query, new KinveyPullCallback<T>() {
 
                     @Override
                     public void onSuccess(KinveyPullResponse<T> pullResult) {
@@ -544,7 +546,7 @@ public class AsyncDataStore<T extends GenericJson> extends DataStore<T> {
 
         @Override
         protected T executeAsync() throws IOException {
-            return (AsyncDataStore.super.save(entity));
+            return (DataStore.super.save(entity));
         }
     }
 }

--- a/android-lib/src/main/java/com/kinvey/android/store/FileStore.java
+++ b/android-lib/src/main/java/com/kinvey/android/store/FileStore.java
@@ -16,7 +16,6 @@
 
 package com.kinvey.android.store;
 
-import com.kinvey.android.AsyncClientRequest;
 import com.kinvey.android.async.AsyncRequest;
 import com.kinvey.android.callback.KinveyDeleteCallback;
 import com.kinvey.java.Query;
@@ -26,7 +25,7 @@ import com.kinvey.java.core.KinveyClientCallback;
 import com.kinvey.java.core.UploaderProgressListener;
 import com.kinvey.java.model.FileMetaData;
 import com.kinvey.java.network.NetworkFileManager;
-import com.kinvey.java.store.FileStore;
+import com.kinvey.java.store.BaseFileStore;
 import com.kinvey.java.store.StoreType;
 
 import java.io.File;
@@ -39,7 +38,7 @@ import java.util.HashMap;
 /**
  * Created by Prots on 2/22/16.
  */
-public class AsyncFileStore extends FileStore {
+public class FileStore extends BaseFileStore {
 
 
 
@@ -62,33 +61,33 @@ public class AsyncFileStore extends FileStore {
         try {
             //UPLOAD METHODS
             asyncMethods.put(FileMethods.UPLOAD_FILE,
-                    FileStore.class.getDeclaredMethod("upload", File.class, UploaderProgressListener.class));
+                    BaseFileStore.class.getDeclaredMethod("upload", File.class, UploaderProgressListener.class));
             asyncMethods.put(FileMethods.UPLOAD_FILE_METADATA,
-                    FileStore.class.getDeclaredMethod("upload", File.class,
+                    BaseFileStore.class.getDeclaredMethod("upload", File.class,
                             FileMetaData.class,
                             UploaderProgressListener.class));
             asyncMethods.put(FileMethods.UPLOAD_STREAM_METADATA,
-                    FileStore.class.getDeclaredMethod("upload", InputStream.class,
+                    BaseFileStore.class.getDeclaredMethod("upload", InputStream.class,
                             FileMetaData.class,
                             UploaderProgressListener.class));
             asyncMethods.put(FileMethods.UPLOAD_STREAM_FILENAME,
-                    FileStore.class.getDeclaredMethod("upload", String.class,
+                    BaseFileStore.class.getDeclaredMethod("upload", String.class,
                             InputStream.class,
                             UploaderProgressListener.class));
 
             //DELETE METHODS
 
             asyncMethods.put(FileMethods.DELETE_ID,
-                    FileStore.class.getDeclaredMethod("delete", String.class));
+                    BaseFileStore.class.getDeclaredMethod("delete", String.class));
 
             //DOWNLOAD METHODS
             asyncMethods.put(FileMethods.DOWNLOAD_FILENAME,
-                    FileStore.class.getDeclaredMethod("download", String.class, String.class, DownloaderProgressListener.class));
+                    BaseFileStore.class.getDeclaredMethod("download", String.class, String.class, DownloaderProgressListener.class));
 
             asyncMethods.put(FileMethods.DOWNLOAD_METADATA,
-                    FileStore.class.getDeclaredMethod("download", FileMetaData.class, OutputStream.class, DownloaderProgressListener.class));
+                    BaseFileStore.class.getDeclaredMethod("download", FileMetaData.class, OutputStream.class, DownloaderProgressListener.class));
             asyncMethods.put(FileMethods.DOWNLOAD_QUERY,
-                    FileStore.class.getDeclaredMethod("download", Query.class, String.class, DownloaderProgressListener.class));
+                    BaseFileStore.class.getDeclaredMethod("download", Query.class, String.class, DownloaderProgressListener.class));
 
         } catch (NoSuchMethodException e) {
             e.printStackTrace();
@@ -97,8 +96,8 @@ public class AsyncFileStore extends FileStore {
 
 
 
-    public AsyncFileStore(NetworkFileManager networkFileManager,
-                          ICacheManager cacheManager, Long ttl, StoreType storeType, String cacheFolder) {
+    public FileStore(NetworkFileManager networkFileManager,
+                     ICacheManager cacheManager, Long ttl, StoreType storeType, String cacheFolder) {
         super(networkFileManager, cacheManager, ttl, storeType, cacheFolder);
     }
 

--- a/android-lib/src/main/java/com/kinvey/android/store/LinkedDataStore.java
+++ b/android-lib/src/main/java/com/kinvey/android/store/LinkedDataStore.java
@@ -19,22 +19,21 @@ package com.kinvey.android.store;
 import com.kinvey.java.AbstractClient;
 import com.kinvey.java.LinkedResources.LinkedGenericJson;
 import com.kinvey.java.network.LinkedNetworkManager;
-import com.kinvey.java.store.LinkedDataStore;
 import com.kinvey.java.store.StoreType;
 
 /**
  * Created by Prots on 3/10/16.
  */
-public class AsyncLinkedDataStore<T extends LinkedGenericJson> extends AsyncDataStore<T> {
+public class LinkedDataStore<T extends LinkedGenericJson> extends DataStore<T> {
     /**
-     * Constructor for creating LinkedDataStore for given collection that will be mapped to itemType class
+     * Constructor for creating LinkedBaseDataStore for given collection that will be mapped to itemType class
      *
      * @param client     Kinvey client instance to work with
      * @param collection collection name
      * @param itemType   class that data should be mapped to
      * @param storeType  type of storage that client want to use
      */
-    public AsyncLinkedDataStore(AbstractClient client, String collection, Class<T> itemType, StoreType storeType) {
+    public LinkedDataStore(AbstractClient client, String collection, Class<T> itemType, StoreType storeType) {
         super(collection, itemType, client, storeType,
                 new LinkedNetworkManager<T>(collection, itemType, client));
     }

--- a/android-lib/src/main/java/com/kinvey/android/store/UserStore.java
+++ b/android-lib/src/main/java/com/kinvey/android/store/UserStore.java
@@ -21,7 +21,7 @@ import com.kinvey.java.auth.KinveyAuthRequest;
 import com.kinvey.java.core.KinveyClientCallback;
 import com.kinvey.java.core.KinveyClientRequestInitializer;
 import com.kinvey.java.dto.User;
-import com.kinvey.java.store.UserStore;
+import com.kinvey.java.store.BaseUserStore;
 import com.kinvey.java.store.UserStoreRequestManager;
 import com.kinvey.java.store.requests.user.GetMICTempURL;
 import com.kinvey.java.store.requests.user.LoginToTempURL;
@@ -29,7 +29,7 @@ import com.kinvey.java.store.requests.user.LogoutRequest;
 
 import java.io.IOException;
 
-public class AsyncUserStore {
+public class UserStore {
 
     private static boolean clearStorage = true;
     private static KinveyUserCallback MICCallback;
@@ -471,25 +471,25 @@ public class AsyncUserStore {
         protected User executeAsync() throws IOException {
             switch(this.type) {
                 case IMPLICIT:
-                    return UserStore.login(client);
+                    return BaseUserStore.login(client);
                 case KINVEY:
-                    return UserStore.login(username, password, client);
+                    return BaseUserStore.login(username, password, client);
                 case FACEBOOK:
-                    return UserStore.loginFacebook(accessToken, client);
+                    return BaseUserStore.loginFacebook(accessToken, client);
                 case GOOGLE:
-                    return UserStore.loginGoogle(accessToken, client);
+                    return BaseUserStore.loginGoogle(accessToken, client);
                 case TWITTER:
-                    return UserStore.loginTwitter(accessToken, accessSecret, consumerKey, consumerSecret, client);
+                    return BaseUserStore.loginTwitter(accessToken, accessSecret, consumerKey, consumerSecret, client);
                 case LINKED_IN:
-                    return UserStore.loginLinkedIn(accessToken, accessSecret, consumerKey, consumerSecret, client);
+                    return BaseUserStore.loginLinkedIn(accessToken, accessSecret, consumerKey, consumerSecret, client);
                 case AUTH_LINK:
-                    return UserStore.loginAuthLink(accessToken, refreshToken, client);
+                    return BaseUserStore.loginAuthLink(accessToken, refreshToken, client);
                 case SALESFORCE:
-                    return UserStore.loginSalesForce(accessToken, client_id, refreshToken, id, client);
+                    return BaseUserStore.loginSalesForce(accessToken, client_id, refreshToken, id, client);
                 case MOBILE_IDENTITY:
-                    return UserStore.loginMobileIdentity(accessToken, client);
+                    return BaseUserStore.loginMobileIdentity(accessToken, client);
                 case CREDENTIALSTORE:
-                    return UserStore.login(credential, client);
+                    return BaseUserStore.login(credential, client);
             }
             return null;
         }
@@ -511,7 +511,7 @@ public class AsyncUserStore {
 
         @Override
         protected User executeAsync() throws IOException {
-            return UserStore.signUp(username, password, client);
+            return BaseUserStore.signUp(username, password, client);
         }
     }
 
@@ -529,7 +529,7 @@ public class AsyncUserStore {
 
         @Override
         protected Void executeAsync() throws IOException {
-            UserStore.destroy(hardDelete, client);
+            BaseUserStore.destroy(hardDelete, client);
             return null;
         }
     }
@@ -554,7 +554,7 @@ public class AsyncUserStore {
             requestManager.setMICRedirectURI(redirectURI);
             GenericJson result = requestManager.getMICToken(token).execute();
 
-            User ret =  UserStore.loginMobileIdentity(result.get("access_token").toString(), client);
+            User ret =  BaseUserStore.loginMobileIdentity(result.get("access_token").toString(), client);
 
             Credential currentCred = client.getStore().load(client.getUser().getId());
             currentCred.setRefreshToken(result.get("refresh_token").toString());
@@ -591,7 +591,7 @@ public class AsyncUserStore {
             LoginToTempURL loginToTempURL = requestManager.MICLoginToTempURL(username, password, tempURL);
             GenericJson accessResult = loginToTempURL.execute();
 
-            User user = UserStore.loginMobileIdentity(accessResult.get("access_token").toString(), client);
+            User user = BaseUserStore.loginMobileIdentity(accessResult.get("access_token").toString(), client);
 
 
             Credential currentCred = client.getStore().load(client.getUser().getId());
@@ -622,9 +622,9 @@ public class AsyncUserStore {
         @Override
         public User executeAsync() throws IOException {
             if (resolves == null){
-                return UserStore.retrieve(client);
+                return BaseUserStore.retrieve(client);
             }else{
-                return UserStore.retrieve(resolves, client);
+                return BaseUserStore.retrieve(resolves, client);
             }
         }
     }
@@ -654,9 +654,9 @@ public class AsyncUserStore {
         @Override
         public User[] executeAsync() throws IOException {
             if (resolves == null){
-                return UserStore.retrieve(query, client);
+                return BaseUserStore.retrieve(query, client);
             }else{
-                return UserStore.retrieve(query, resolves, client);
+                return BaseUserStore.retrieve(query, resolves, client);
             }
         }
     }
@@ -674,7 +674,7 @@ public class AsyncUserStore {
 
         @Override
         protected User executeAsync() throws IOException {
-            return UserStore.convenience(client);
+            return BaseUserStore.convenience(client);
         }
     }
 
@@ -691,7 +691,7 @@ public class AsyncUserStore {
 
         @Override
         protected User executeAsync() throws IOException {
-            return UserStore.save(client);
+            return BaseUserStore.save(client);
         }
     }
 
@@ -710,7 +710,7 @@ public class AsyncUserStore {
 
         @Override
         protected Void executeAsync() throws IOException {
-            UserStore.changePassword(password, client);
+            BaseUserStore.changePassword(password, client);
             return null;
         }
     }
@@ -731,7 +731,7 @@ public class AsyncUserStore {
 
         @Override
         protected Void executeAsync() throws IOException {
-            UserStore.resetPassword(usernameOrEmail, client);
+            BaseUserStore.resetPassword(usernameOrEmail, client);
             return null;
         }
     }
@@ -751,7 +751,7 @@ public class AsyncUserStore {
 
         @Override
         protected Void executeAsync() throws IOException {
-            UserStore.exists(username, client);
+            BaseUserStore.exists(username, client);
             return null;
         }
     }
@@ -771,7 +771,7 @@ public class AsyncUserStore {
 
         @Override
         protected User executeAsync() throws IOException {
-            UserStore.get(userId, client);
+            BaseUserStore.get(userId, client);
             return null;
         }
     }
@@ -789,7 +789,7 @@ public class AsyncUserStore {
 
         @Override
         protected Void executeAsync() throws IOException {
-            UserStore.sendEmailConfirmation(client);
+            BaseUserStore.sendEmailConfirmation(client);
             return null;
         }
     }
@@ -809,7 +809,7 @@ public class AsyncUserStore {
 
         @Override
         protected Void executeAsync() throws IOException {
-            UserStore.forgotUsername(client, email);
+            BaseUserStore.forgotUsername(client, email);
             return null;
         }
     }
@@ -831,7 +831,7 @@ public class AsyncUserStore {
 
         @Override
         protected User executeAsync() throws IOException {
-            return UserStore.loginKinveyAuthToken(userID, authToken, client);
+            return BaseUserStore.loginKinveyAuthToken(userID, authToken, client);
 
         }
     }

--- a/android-lib/src/main/java/com/kinvey/android/ui/MICLoginActivity.java
+++ b/android-lib/src/main/java/com/kinvey/android/ui/MICLoginActivity.java
@@ -23,8 +23,7 @@ import android.webkit.WebView;
 
 import com.kinvey.android.Client;
 import com.kinvey.android.R;
-import com.kinvey.android.store.AsyncUserStore;
-import com.kinvey.java.dto.User;
+import com.kinvey.android.store.UserStore;
 
 /***
  * Provides a WebView for easy logging into MIC.
@@ -63,7 +62,7 @@ public class MICLoginActivity extends Activity {
     public void onNewIntent(Intent intent){
 
         super.onNewIntent(intent);
-        AsyncUserStore.onOAuthCallbackRecieved(intent, Client.sharedInstance());
+        UserStore.onOAuthCallbackRecieved(intent, Client.sharedInstance());
         this.finish();
     }
 }

--- a/java-api-core/java-api-core.iml
+++ b/java-api-core/java-api-core.iml
@@ -18,8 +18,8 @@
     <output-test url="file://$MODULE_DIR$/build/classes/test" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />

--- a/java-api-core/src/com/kinvey/java/AbstractClient.java
+++ b/java-api-core/src/com/kinvey/java/AbstractClient.java
@@ -34,7 +34,6 @@ import com.kinvey.java.auth.ClientUser;
 import com.kinvey.java.auth.Credential;
 import com.kinvey.java.auth.CredentialManager;
 import com.kinvey.java.auth.CredentialStore;
-import com.kinvey.java.auth.KinveyAuthRequest;
 import com.kinvey.java.cache.ICacheManager;
 import com.kinvey.java.core.AbstractKinveyClientRequest;
 import com.kinvey.java.core.AbstractKinveyJsonClient;
@@ -42,10 +41,9 @@ import com.kinvey.java.core.KinveyClientRequestInitializer;
 import com.kinvey.java.dto.User;
 import com.kinvey.java.network.NetworkFileManager;
 import com.kinvey.java.query.MongoQueryFilter;
-import com.kinvey.java.store.DataStore;
-import com.kinvey.java.store.FileStore;
+import com.kinvey.java.store.BaseDataStore;
+import com.kinvey.java.store.BaseFileStore;
 import com.kinvey.java.store.StoreType;
-import com.kinvey.java.store.UserStoreRequestManager;
 import com.kinvey.java.sync.SyncManager;
 
 /**
@@ -484,15 +482,10 @@ public abstract class AbstractClient extends AbstractKinveyJsonClient {
 
     public abstract ICacheManager getCacheManager();
 
-    public <T extends GenericJson> DataStore<T> dataStore(String collection,
-                                                          Class<T> clazz, StoreType storeType){
-        return new DataStore<T>(this, collection, clazz, storeType);
-    }
-
     public abstract String getFileCacheFolder();
 
-    public FileStore getFileStore(StoreType storeType){
-        return new FileStore(new NetworkFileManager(this),
+    public BaseFileStore getFileStore(StoreType storeType){
+        return new BaseFileStore(new NetworkFileManager(this),
                 getCacheManager(), 60*1000*1000L,
                 storeType, getFileCacheFolder());
     }

--- a/java-api-core/src/com/kinvey/java/LinkedResources/GetLinkedResourceClientRequest.java
+++ b/java-api-core/src/com/kinvey/java/LinkedResources/GetLinkedResourceClientRequest.java
@@ -26,7 +26,7 @@ import com.kinvey.java.Logger;
 import com.kinvey.java.core.AbstractKinveyJsonClientRequest;
 import com.kinvey.java.core.DownloaderProgressListener;
 import com.kinvey.java.model.FileMetaData;
-import com.kinvey.java.store.FileStore;
+import com.kinvey.java.store.BaseFileStore;
 import com.kinvey.java.store.StoreType;
 
 /**
@@ -112,7 +112,7 @@ public class GetLinkedResourceClientRequest<T> extends AbstractKinveyJsonClientR
 
                 entity.getFile(key).setOutput(new ByteArrayOutputStream());
 
-                FileStore store = getAbstractKinveyClient().getFileStore(StoreType.SYNC);
+                BaseFileStore store = getAbstractKinveyClient().getFileStore(StoreType.SYNC);
 
                 FileMetaData meta = new FileMetaData();
                 if (((Map) entity.get(key)).containsKey("_id")){

--- a/java-api-core/src/com/kinvey/java/LinkedResources/SaveLinkedResourceClientRequest.java
+++ b/java-api-core/src/com/kinvey/java/LinkedResources/SaveLinkedResourceClientRequest.java
@@ -18,19 +18,17 @@ package com.kinvey.java.LinkedResources;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 
 import com.google.api.client.http.InputStreamContent;
 import com.google.api.client.json.GenericJson;
 import com.kinvey.java.AbstractClient;
 import com.kinvey.java.Logger;
 import com.kinvey.java.MimeTypeFinder;
-import com.kinvey.java.annotations.ReferenceHelper;
 import com.kinvey.java.core.AbstractKinveyJsonClientRequest;
 import com.kinvey.java.core.MediaHttpUploader;
 import com.kinvey.java.core.UploaderProgressListener;
 import com.kinvey.java.model.FileMetaData;
-import com.kinvey.java.store.FileStore;
+import com.kinvey.java.store.BaseFileStore;
 import com.kinvey.java.store.StoreType;
 
 /**
@@ -123,7 +121,7 @@ public class SaveLinkedResourceClientRequest<T> extends AbstractKinveyJsonClient
                             }
                         };
 
-                        FileStore fileStore = getAbstractKinveyClient().getFileStore(StoreType.SYNC);
+                        BaseFileStore fileStore = getAbstractKinveyClient().getFileStore(StoreType.SYNC);
 
                         LinkedFile lf = ((LinkedGenericJson) getJsonContent()).getFile(key);
                         FileMetaData meta = new FileMetaData(lf.getId());

--- a/java-api-core/src/com/kinvey/java/core/AbstractKinveyClient.java
+++ b/java-api-core/src/com/kinvey/java/core/AbstractKinveyClient.java
@@ -27,7 +27,7 @@ import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.util.ObjectParser;
 import com.kinvey.java.KinveyException;
 import com.kinvey.java.Logger;
-import com.kinvey.java.store.FileStore;
+import com.kinvey.java.store.BaseFileStore;
 import com.kinvey.java.store.StoreType;
 
 /**
@@ -93,9 +93,9 @@ public abstract class AbstractKinveyClient {
 
 
     /**
-     * Access to the FileStore service where files of all sizes including images and videos can be uploaded and downloaded.
+     * Access to the BaseFileStore service where files of all sizes including images and videos can be uploaded and downloaded.
      */
-    public abstract FileStore getFileStore(StoreType storeType);
+    public abstract BaseFileStore getFileStore(StoreType storeType);
 
 
     /**

--- a/java-api-core/src/com/kinvey/java/core/AbstractKinveyClientRequest.java
+++ b/java-api-core/src/com/kinvey/java/core/AbstractKinveyClientRequest.java
@@ -28,9 +28,6 @@ import com.kinvey.java.KinveyException;
 import com.kinvey.java.Logger;
 import com.kinvey.java.auth.Credential;
 import com.kinvey.java.auth.KinveyAuthRequest;
-import com.kinvey.java.dto.User;
-import com.kinvey.java.store.FileCache;
-import com.kinvey.java.store.UserStore;
 import com.kinvey.java.store.UserStoreRequestManager;
 
 /**

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
@@ -21,10 +21,8 @@ import com.google.common.base.Preconditions;
 import com.kinvey.java.AbstractClient;
 import com.kinvey.java.Query;
 import com.kinvey.java.cache.ICache;
-import com.kinvey.java.core.KinveyClientCallback;
 import com.kinvey.java.network.NetworkManager;
 import com.kinvey.java.store.requests.data.PushRequest;
-import com.kinvey.java.store.requests.data.ReadRequest;
 import com.kinvey.java.store.requests.data.delete.DeleteIdsRequest;
 import com.kinvey.java.store.requests.data.delete.DeleteQueryRequest;
 import com.kinvey.java.store.requests.data.delete.DeleteSingleRequest;
@@ -36,12 +34,11 @@ import com.kinvey.java.store.requests.data.read.ReadIdsRequest;
 import com.kinvey.java.store.requests.data.read.ReadQueryRequest;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 
-public class DataStore<T extends GenericJson> {
+public class BaseDataStore<T extends GenericJson> {
 
     protected final AbstractClient client;
     private final String collection;
@@ -55,18 +52,18 @@ public class DataStore<T extends GenericJson> {
 
 
     /**
-     * Constructor for creating DataStore for given collection that will be mapped to itemType class
+     * Constructor for creating BaseDataStore for given collection that will be mapped to itemType class
      * @param client Kinvey client instance to work with
      * @param collection collection name
      * @param itemType class that data should be mapped to
      * @param storeType type of storage that client want to use
      */
-    public DataStore(AbstractClient client, String collection, Class<T> itemType, StoreType storeType){
+    protected BaseDataStore(AbstractClient client, String collection, Class<T> itemType, StoreType storeType){
         this(client, collection, itemType, storeType, new NetworkManager<T>(collection, itemType, client));
     }
 
-    protected  DataStore(AbstractClient client, String collection, Class<T> itemType, StoreType storeType,
-                         NetworkManager<T> networkManager){
+    protected BaseDataStore(AbstractClient client, String collection, Class<T> itemType, StoreType storeType,
+                            NetworkManager<T> networkManager){
         Preconditions.checkNotNull(client, "client must not be null.");
         Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
         this.storeType = storeType;
@@ -76,6 +73,13 @@ public class DataStore<T extends GenericJson> {
         cache = client.getCacheManager().getCache(collection, itemType, storeType.ttl);
         this.networkManager = networkManager;
         this.collectionName = collection;
+    }
+
+    public static <T extends GenericJson> BaseDataStore<T> collection(String collectionName, Class<T> myClass, StoreType storeType, AbstractClient client) {
+        Preconditions.checkNotNull(collectionName, "collectionName cannot be null.");
+        Preconditions.checkNotNull(storeType, "storeType cannot be null.");
+        Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
+        return new BaseDataStore<T>(client, collectionName, myClass, storeType);
     }
 
     /**
@@ -266,7 +270,7 @@ public class DataStore<T extends GenericJson> {
 
 
     /**
-     * Set store type for current DataStore
+     * Set store type for current BaseDataStore
      * @param storeType
      */
     public void setStoreType(StoreType storeType) {
@@ -276,7 +280,7 @@ public class DataStore<T extends GenericJson> {
 
     /**
      * Getter for client
-     * @return Client instance for given DataStore
+     * @return Client instance for given BaseDataStore
      */
     public AbstractClient getClient() {
         return client;

--- a/java-api-core/src/com/kinvey/java/store/BaseFileStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseFileStore.java
@@ -46,7 +46,7 @@ import java.io.OutputStream;
 import java.util.UUID;
 
 
-public class FileStore {
+public class BaseFileStore {
 
     private static final String CACHE_FILE_PATH = "KinveyCachePath";
 
@@ -57,7 +57,7 @@ public class FileStore {
     private final ICache<FileMetadataWithPath> cache;
     private StoreType storeType;
 
-    public FileStore(NetworkFileManager networkFileManager, ICacheManager cacheManager, Long ttl, StoreType storeType, String cacheFolder){
+    public BaseFileStore(NetworkFileManager networkFileManager, ICacheManager cacheManager, Long ttl, StoreType storeType, String cacheFolder){
 
         this.networkFileManager = networkFileManager;
         this.cacheManager = cacheManager;

--- a/java-api-core/src/com/kinvey/java/store/BaseUserStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseUserStore.java
@@ -10,7 +10,7 @@ import com.kinvey.java.dto.User;
 
 import java.io.IOException;
 
-public abstract class UserStore {
+public abstract class BaseUserStore {
 
     public static User signUp(String userId, String password, AbstractClient client) throws IOException {
         return new UserStoreRequestManager(client, createBuilder(client)).createBlocking(userId, password).execute();

--- a/java-api-core/src/com/kinvey/java/store/LinkedBaseDataStore.java
+++ b/java-api-core/src/com/kinvey/java/store/LinkedBaseDataStore.java
@@ -20,16 +20,16 @@ import com.kinvey.java.AbstractClient;
 import com.kinvey.java.LinkedResources.LinkedGenericJson;
 import com.kinvey.java.network.LinkedNetworkManager;
 
-public class LinkedDataStore<T extends LinkedGenericJson> extends DataStore<T> {
+public class LinkedBaseDataStore<T extends LinkedGenericJson> extends BaseDataStore<T> {
     /**
-     * Constructor for creating LinkedDataStore for given collection that will be mapped to itemType class
+     * Constructor for creating LinkedBaseDataStore for given collection that will be mapped to itemType class
      *
      * @param client     Kinvey client instance to work with
      * @param collection collection name
      * @param itemType   class that data should be mapped to
      * @param storeType  type of storage that client want to use
      */
-    public LinkedDataStore(AbstractClient client, String collection, Class<T> itemType, StoreType storeType) {
+    public LinkedBaseDataStore(AbstractClient client, String collection, Class<T> itemType, StoreType storeType) {
         super(client, collection, itemType, storeType,
                 new LinkedNetworkManager<T>(collection, itemType, client));
     }

--- a/java-api-core/src/com/kinvey/java/sync/SyncManager.java
+++ b/java-api-core/src/com/kinvey/java/sync/SyncManager.java
@@ -25,7 +25,7 @@ import com.kinvey.java.cache.ICache;
 import com.kinvey.java.cache.ICacheManager;
 import com.kinvey.java.core.AbstractKinveyJsonClientRequest;
 import com.kinvey.java.query.MongoQueryFilter;
-import com.kinvey.java.store.DataStore;
+import com.kinvey.java.store.BaseDataStore;
 import com.kinvey.java.store.StoreType;
 import com.kinvey.java.sync.dto.SyncCollections;
 import com.kinvey.java.sync.dto.SyncRequest;
@@ -161,8 +161,7 @@ public class SyncManager {
             e.printStackTrace();
         }
 
-
-        DataStore networkDataStore = client.dataStore(request.getCollectionName(), GenericJson.class, StoreType.NETWORK);
+        BaseDataStore networkDataStore = BaseDataStore.collection(request.getCollectionName(), GenericJson.class, StoreType.NETWORK, client);
 
         if (request.getHttpVerb().equals(SyncRequest.HttpVerb.PUT) || request.getHttpVerb().equals((SyncRequest.HttpVerb.POST))) {
 

--- a/java-api-core/test/com/kinvey/java/UserTest.java
+++ b/java-api-core/test/com/kinvey/java/UserTest.java
@@ -23,7 +23,6 @@ import com.kinvey.java.auth.KinveyAuthRequest;
 import com.kinvey.java.auth.ThirdPartyIdentity;
 import com.kinvey.java.core.KinveyMockUnitTest;
 import com.kinvey.java.dto.User;
-import com.kinvey.java.store.UserStore;
 import com.kinvey.java.store.UserStoreRequestManager;
 import com.kinvey.java.store.requests.user.Delete;
 import com.kinvey.java.store.requests.user.EmailVerification;


### PR DESCRIPTION
We used a convention in the past to refer to all Android "store" classes with the "Async" prefix. This was because the root name (such as AppData) referred to the Java equivalent.

With Android being the more frequently used platform, it seems better to refer to the Android classes with the root name (i.e. DataStore or UserStore) and the Java / Base classes with a prefix (in this case, "Base").  

This is also in keeping with the other mobile platform SDKs.
