### PR TITLE
MLIBZ-2643 Time from Date object in milliseconds before saving to the DataStore isn't equaled time after getting the entity from the DataStore

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/model/DateExample.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/model/DateExample.java
@@ -1,0 +1,45 @@
+package com.kinvey.androidTest.model;
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.util.Key;
+
+import java.util.Date;
+
+public class DateExample extends GenericJson {
+
+    public static final String COLLECTION = "DateExample";
+
+    @Key("_id")
+    protected String id;
+
+    @Key
+    private String field;
+
+    @Key
+    private Date date;
+
+    public DateExample() {
+        }
+
+
+    public DateExample(String field, Date date) {
+        this.field = field;
+        this.date = date;
+    }
+
+    public String getId() {
+        return field;
+    }
+
+    public void setId(String id) {
+        this.field = id;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+}

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -508,6 +508,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
 
         item.set(ID, clone.get(ID));
 
+        item.remove(ClassHash.TTL);
         return item.get(ID).toString();
     }
 

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -501,7 +501,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
 
     private String insertOrUpdate(T item, DynamicRealm mRealm){
 
-        T clone = (T)item.clone();
+        T clone = (T)item;
         clone.put(ClassHash.TTL, getItemExpireTime());
 
         ClassHash.saveData(mCollection, mRealm, mCollectionItemClass, clone);

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -501,14 +501,12 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
 
     private String insertOrUpdate(T item, DynamicRealm mRealm){
 
-        T clone = (T)item;
-        clone.put(ClassHash.TTL, getItemExpireTime());
+        item.put(ClassHash.TTL, getItemExpireTime());
 
-        ClassHash.saveData(mCollection, mRealm, mCollectionItemClass, clone);
-
-        item.set(ID, clone.get(ID));
+        ClassHash.saveData(mCollection, mRealm, mCollectionItemClass, item);
 
         item.remove(ClassHash.TTL);
+
         return item.get(ID).toString();
     }
 


### PR DESCRIPTION
#### Description
The goal of the task is to find why time from Date object in milliseconds before saving to the DataStore isn't equaled time after getting the entity from the DataStore

#### Changes
Add test for entity with date and fix RealmCache

#### Tests
Instrumented
