### PR TITLE
Access Token path might be affected by the MIC API version.

### DIFF
--- a/java-api-core/src/com/kinvey/java/store/requests/user/GetMICAccessToken.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/user/GetMICAccessToken.java
@@ -25,12 +25,14 @@ import com.kinvey.java.store.UserStoreRequestManager;
  * Created by Prots on 2/12/16.
  */
 public final class GetMICAccessToken extends AbstractKinveyClientRequest<GenericJson> {
-    private static final String REST_PATH = "oauth/token";
+    // Base path, without the MIC API version.
+    private static final String BASE_TOKEN_PATH = "oauth/token";
 
     private UserStoreRequestManager userStoreRequestManager;
 
     public GetMICAccessToken(UserStoreRequestManager userStoreRequestManager, HttpContent content) {
-        super(userStoreRequestManager.getClient(), userStoreRequestManager.getClient().getMICHostName(), "POST", REST_PATH, content, GenericJson.class);
+        super(userStoreRequestManager.getClient(), userStoreRequestManager.getClient().getMICHostName(), "POST",
+                "/" + userStoreRequestManager.getClient().getMICApiVersion() + "/" + BASE_TOKEN_PATH, content, GenericJson.class);
         this.userStoreRequestManager = userStoreRequestManager;
     }
 }

--- a/java-api-core/test/com/kinvey/java/BaseUserTest.java
+++ b/java-api-core/test/com/kinvey/java/BaseUserTest.java
@@ -288,9 +288,10 @@ public class BaseUserTest extends KinveyMockUnitTest {
     	}catch(Exception e){}
 
 
-
+        // Construct the full token path. Might be affected by the MIC API version.
+        String fullTokenPath = "https://www.google.com/" + getClient().getMICApiVersion() + "/oauth/token";
     	GetMICAccessToken getToken = requestManager.getMICToken("myCODE", null);
-    	assertEquals("https://www.google.com/oauth/token", getToken.buildHttpRequest().getUrl().toString());
+        assertEquals(fullTokenPath, getToken.buildHttpRequest().getUrl().toString());
     }
 
     public void testMICLoginWithAccessToken() throws IOException{


### PR DESCRIPTION
#### Description
Currently the path for retrieving the access token is hardcoded and changes to the MIC API version do not get applied. This fix makes sure that the MIC API version that's set from the code is being applied.

#### Changes
`mKinveyClient.setMICApiVersion("3");`  this call now makes sure that the token request goes to the correct path.

#### Tests
The test reflecting this from `BaseUserTest.java` file has been fixed and adjusted.
