### PR TITLE
MLIBZ-2859: Client.getActiveUser() returns only userId

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/UserStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/UserStoreTest.java
@@ -57,7 +57,6 @@ import static com.kinvey.androidTest.TestManager.PASSWORD;
 import static com.kinvey.androidTest.TestManager.USERNAME;
 import static com.kinvey.java.Constants.AUTH_TOKEN;
 import static com.kinvey.java.model.KinveyMetaData.KMD;
-import static com.kinvey.java.store.UserStoreRequestManager.USER_COLLECTION_NAME;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
@@ -72,6 +71,7 @@ public class UserStoreTest {
     private Client client = null;
 
     public static final String INSUFFICIENT_CREDENTIAL_TYPE = "InsufficientCredentials";
+    private static final String ACTIVE_USER_COLLECTION_NAME = "active_user_info";
 
     private static class DefaultKinveyClientCallback implements KinveyClientCallback<User> {
 
@@ -1932,7 +1932,7 @@ public class UserStoreTest {
         DefaultKinveyClientCallback callback = login(USERNAME, PASSWORD);
         assertNull(callback.error);
         assertNotNull(callback.result);
-        User user = client.getCacheManager().getCache(USER_COLLECTION_NAME, User.class, Long.MAX_VALUE).get().get(0);
+        User user = client.getCacheManager().getCache(ACTIVE_USER_COLLECTION_NAME, User.class, Long.MAX_VALUE).get().get(0);
         assertNotNull(user.getUsername());
         assertEquals(USERNAME, user.getUsername());
         assertEquals(USERNAME, client.getActiveUser().getUsername());

--- a/android-lib/src/main/java/com/kinvey/android/Client.java
+++ b/android-lib/src/main/java/com/kinvey/android/Client.java
@@ -899,7 +899,6 @@ public class Client<T extends User> extends AbstractClient<T> {
             if (!Strings.isNullOrEmpty(this.instanceID)) {
                 client.setMICHostName(Constants.PROTOCOL_HTTPS + instanceID + Constants.HYPHEN + Constants.HOSTNAME_AUTH);
             }
-            client.getUserCacheManager().getCache(USER_COLLECTION_NAME, client.getUserClass(), Long.MAX_VALUE);
             try {
                 Credential credential = retrieveUserFromCredentialStore(client);
                 if (credential != null) {

--- a/android-lib/src/main/java/com/kinvey/android/Client.java
+++ b/android-lib/src/main/java/com/kinvey/android/Client.java
@@ -61,8 +61,6 @@ import java.util.List;
 
 import io.realm.Realm;
 
-import static com.kinvey.java.store.UserStoreRequestManager.USER_COLLECTION_NAME;
-
 /**
  * This class is an implementation of a {@link com.kinvey.java.AbstractClient} with default settings for the Android operating
  * system.

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCacheManager.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCacheManager.java
@@ -44,6 +44,8 @@ import io.realm.RealmResults;
 import io.realm.RealmSchema;
 import io.realm.exceptions.RealmFileException;
 
+import static com.kinvey.java.Constants.ACCESS_ERROR;
+
 /**
  * Created by Prots on 1/26/16.
  */
@@ -366,7 +368,7 @@ public class RealmCacheManager implements ICacheManager {
                 realm = DynamicRealm.getInstance(getRealmConfiguration());
             } catch (RealmFileException exception) {
                 if (exception.getKind() != null && exception.getKind().name().equals("ACCESS_ERROR")) {
-                    throw new KinveyException("Access Error", "Use correct encryption key", "You are using wrong encryption key");
+                    throw new KinveyException(ACCESS_ERROR, "Use correct encryption key", "You are using wrong encryption key");
                 } else {
                    throw exception;
                 }

--- a/java-api-core/src/com/kinvey/java/AbstractClient.java
+++ b/java-api-core/src/com/kinvey/java/AbstractClient.java
@@ -564,6 +564,8 @@ public abstract class AbstractClient<T extends BaseUser> extends AbstractKinveyJ
 
     public abstract ICacheManager getCacheManager();
 
+    public abstract ICacheManager getUserCacheManager();
+
     public abstract String getFileCacheFolder();
 
     public BaseFileStore getFileStore(StoreType storeType){

--- a/java-api-core/src/com/kinvey/java/Constants.java
+++ b/java-api-core/src/com/kinvey/java/Constants.java
@@ -14,8 +14,10 @@ public final class Constants {
     public static final String QUERY = "query";
 
     public static final String _ID = "_id";
+    public static final String AUTH_TOKEN = "authtoken";
     public static final String _KMD = "_acl";
     public static final String _ACL = "_acl";
+    public static final String ACCESS_ERROR = "Access Error";
 
     public static final String DELETE = "DELETE";
     public static final String REQUEST_METHOD = "requestMethod";

--- a/java-api-core/src/com/kinvey/java/auth/Credential.java
+++ b/java-api-core/src/com/kinvey/java/auth/Credential.java
@@ -16,12 +16,13 @@
 
 package com.kinvey.java.auth;
 
-import com.google.api.client.json.GenericJson;
 import com.kinvey.java.core.AbstractKinveyClientRequest;
 import com.kinvey.java.core.KinveyRequestInitializer;
 import com.kinvey.java.dto.BaseUser;
 
 import java.util.Map;
+
+import static com.kinvey.java.Constants.AUTH_TOKEN;
 
 /**
  * @author m0rganic
@@ -32,7 +33,6 @@ public class Credential implements KinveyRequestInitializer, java.io.Serializabl
     private static final long serialVersionUID = 1L;
 
     private final static String AUTH_N_HEADER_FORMAT = "Kinvey %s";
-    private final static String AUTH_TOKEN = "authtoken";
     private final static String KMD = "_kmd";
 
     private String userId;

--- a/java-api-core/src/com/kinvey/java/auth/KinveyAuthResponse.java
+++ b/java-api-core/src/com/kinvey/java/auth/KinveyAuthResponse.java
@@ -24,6 +24,8 @@ import com.google.api.client.util.Key;
 
 import java.io.IOException;
 
+import static com.kinvey.java.Constants.AUTH_TOKEN;
+
 /**
  * @author m0rganic
  * @since 2.0
@@ -69,7 +71,7 @@ public class KinveyAuthResponse extends GenericJson {
         @Key("lmt")
         private String lastModifiedTime;
 
-        @Key("authtoken")
+        @Key(AUTH_TOKEN)
         private String authToken;
 
         public KinveyUserMetadata() {}

--- a/java-api-core/src/com/kinvey/java/dto/BaseUser.java
+++ b/java-api-core/src/com/kinvey/java/dto/BaseUser.java
@@ -19,10 +19,16 @@ package com.kinvey.java.dto;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.util.Key;
 
+import java.util.Map;
+
+import static com.kinvey.java.Constants.AUTH_TOKEN;
+import static com.kinvey.java.model.KinveyMetaData.KMD;
+
 /**
  * Created by Prots on 2/12/16.
  */
 public class BaseUser extends GenericJson {
+
     @Key("_id")
     private String id;
 
@@ -48,6 +54,16 @@ public class BaseUser extends GenericJson {
 
     public void setAuthToken(String authToken) {
         this.authToken = authToken;
+    }
+
+    public void setAuthTokenToKmd(String authToken) {
+        if (get(KMD) != null) {
+            Map<String, String> kmd = (Map<String, String>)get(KMD);
+            if (kmd != null) {
+                kmd.put(AUTH_TOKEN, authToken);
+                put(KMD, kmd);
+            }
+        }
     }
 
     public String getAuthToken() {

--- a/java-api-core/src/com/kinvey/java/store/UserStoreRequestManager.java
+++ b/java-api-core/src/com/kinvey/java/store/UserStoreRequestManager.java
@@ -63,7 +63,7 @@ import java.util.Map;
 public class UserStoreRequestManager<T extends BaseUser> {
 
 
-    public static final String USER_COLLECTION_NAME = "user";
+    public static final String USER_COLLECTION_NAME = "active_user_info";
     public static final String GRANT_TYPE = "grant_type";
     public static final String USERNAME_PARAM = "username";
     public static final String PASSWORD_PARAM = "password";
@@ -816,10 +816,16 @@ public class UserStoreRequestManager<T extends BaseUser> {
                 throw new NullPointerException(e.getMessage());
             }
             if (this.type == UserStoreRequestManager.LoginType.CREDENTIALSTORE) {
-                return initUser(credential, loggedUser);
+                initUser(credential, loggedUser);
+                T savedUser = client.getUserCacheManager().getCache(USER_COLLECTION_NAME, client.getUserClass(), Long.MAX_VALUE)
+                        .get(loggedUser.getId());
+                return savedUser != null ? initUser(savedUser) : loggedUser;
             }
             loggedUser = this.request.execute(myClazz);
-            //if (response.)
+            if (client.getUserCacheManager() != null) {
+                client.getUserCacheManager().getCache(USER_COLLECTION_NAME, client.getUserClass(), Long.MAX_VALUE)
+                        .save(loggedUser);
+            }
             return initUser(loggedUser);
         }
     }

--- a/java-api-core/src/com/kinvey/java/store/UserStoreRequestManager.java
+++ b/java-api-core/src/com/kinvey/java/store/UserStoreRequestManager.java
@@ -66,7 +66,8 @@ import static com.kinvey.java.Constants.ACCESS_ERROR;
 public class UserStoreRequestManager<T extends BaseUser> {
 
 
-    public static final String USER_COLLECTION_NAME = "active_user_info";
+    public static final String USER_COLLECTION_NAME = "user";
+    private static final String ACTIVE_USER_COLLECTION_NAME = "active_user_info";
     public static final String GRANT_TYPE = "grant_type";
     public static final String USERNAME_PARAM = "username";
     public static final String PASSWORD_PARAM = "password";
@@ -822,7 +823,7 @@ public class UserStoreRequestManager<T extends BaseUser> {
                 initUser(credential, loggedUser); //only token and user_id is initialized here
                 T savedUser = null;
                 try {
-                    savedUser = client.getUserCacheManager().getCache(USER_COLLECTION_NAME, client.getUserClass(), Long.MAX_VALUE)
+                    savedUser = client.getUserCacheManager().getCache(ACTIVE_USER_COLLECTION_NAME, client.getUserClass(), Long.MAX_VALUE)
                             .get(loggedUser.getId()); //getting full user info from cache
                     if (savedUser != null) {
                         savedUser.setAuthToken(loggedUser.getAuthToken());
@@ -840,7 +841,7 @@ public class UserStoreRequestManager<T extends BaseUser> {
             initUser(loggedUser);
             try {
                 if (client.getUserCacheManager() != null) {
-                    client.getUserCacheManager().getCache(USER_COLLECTION_NAME, client.getUserClass(), Long.MAX_VALUE)
+                    client.getUserCacheManager().getCache(ACTIVE_USER_COLLECTION_NAME, client.getUserClass(), Long.MAX_VALUE)
                             .save(loggedUser);
                 }
             } catch (KinveyException e) {

--- a/java-api-core/test/com/kinvey/java/core/KinveyMockUnitTest.java
+++ b/java-api-core/test/com/kinvey/java/core/KinveyMockUnitTest.java
@@ -141,6 +141,11 @@ public abstract class KinveyMockUnitTest<T extends BaseUser> extends TestCase {
         }
 
         @Override
+        public ICacheManager getUserCacheManager() {
+            return null;
+        }
+
+        @Override
         public String getFileCacheFolder() {
             return null;
         }

--- a/java-api-core/test/com/kinvey/java/testing/MockKinveyJsonClient.java
+++ b/java-api-core/test/com/kinvey/java/testing/MockKinveyJsonClient.java
@@ -113,6 +113,11 @@ super(transport, httpRequestInitializer, rootUrl, servicePath, objectParser, kin
     }
 
     @Override
+    public ICacheManager getUserCacheManager() {
+        return null;
+    }
+
+    @Override
     public String getFileCacheFolder() {
         return null;
     }


### PR DESCRIPTION
#### Description
If login to an app, then to close the app and open it again `client.getActiveUser()` returns only user id, even if user contained some additional filled fields (userName etc). 

#### Changes
Added saving user info to realm table, except auth_token. 

#### Tests
Instrumented
