### PR TITLE
MLIBZ-2843: Create mock responses to simulate user and login server errors (5xx)

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/DefaultKinveyClientCallback.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/DefaultKinveyClientCallback.java
@@ -1,0 +1,33 @@
+package com.kinvey.androidTest.store.user;
+
+import com.kinvey.android.model.User;
+import com.kinvey.java.core.KinveyClientCallback;
+
+import java.util.concurrent.CountDownLatch;
+
+public class DefaultKinveyClientCallback implements KinveyClientCallback<User> {
+
+    private CountDownLatch latch;
+    User result;
+    Throwable error;
+
+    DefaultKinveyClientCallback(CountDownLatch latch) {
+        this.latch = latch;
+    }
+
+    @Override
+    public void onSuccess(User user) {
+        this.result = user;
+        finish();
+    }
+
+    @Override
+    public void onFailure(Throwable error) {
+        this.error = error;
+        finish();
+    }
+
+    private void finish() {
+        latch.countDown();
+    }
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/DefaultKinveyVoidCallback.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/DefaultKinveyVoidCallback.java
@@ -1,0 +1,32 @@
+package com.kinvey.androidTest.store.user;
+
+import com.kinvey.java.core.KinveyClientCallback;
+
+import java.util.concurrent.CountDownLatch;
+
+public class DefaultKinveyVoidCallback implements KinveyClientCallback<Void> {
+
+    private CountDownLatch latch;
+    Void result;
+    Throwable error;
+
+    DefaultKinveyVoidCallback(CountDownLatch latch) {
+        this.latch = latch;
+    }
+
+    @Override
+    public void onSuccess(Void result) {
+        this.result = result;
+        finish();
+    }
+
+    @Override
+    public void onFailure(Throwable error) {
+        this.error = error;
+        finish();
+    }
+
+    private void finish() {
+        latch.countDown();
+    }
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockClient.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockClient.java
@@ -13,16 +13,17 @@ import com.kinvey.java.core.AbstractKinveyClientRequest;
 import com.kinvey.java.core.KinveyClientRequestInitializer;
 import com.kinvey.java.core.KinveyHeaders;
 
-public class MockedClient<T extends User> extends Client<T> {
+public class MockClient<T extends User> extends Client<T> {
 
 
-    private MockedClient(HttpTransport transport, HttpRequestInitializer httpRequestInitializer, String rootUrl, String servicePath, JsonObjectParser objectParser, KinveyClientRequestInitializer kinveyRequestInitializer, CredentialStore store, BackOffPolicy requestPolicy, byte[] encryptionKey, Context context) {
+    private MockClient(HttpTransport transport, HttpRequestInitializer httpRequestInitializer, String rootUrl, String servicePath, JsonObjectParser objectParser, KinveyClientRequestInitializer kinveyRequestInitializer, CredentialStore store, BackOffPolicy requestPolicy, byte[] encryptionKey, Context context) {
         super(transport, httpRequestInitializer, rootUrl, servicePath, objectParser, kinveyRequestInitializer, store, requestPolicy, encryptionKey, context);
     }
 
-    public static class Builder<T extends User> extends Client.Builder {
+    public static class Builder<T extends User> extends Client.Builder<T> {
 
         Context context;
+        private Class userClass = null;
 
         public Builder(Context context) {
             super(context);
@@ -30,9 +31,17 @@ public class MockedClient<T extends User> extends Client<T> {
         }
 
         @Override
-        public MockedClient build() {
-            return new MockedClient(new MockHttpTransport(), getHttpRequestInitializer(), getBaseUrl(), getServicePath(),
+        public MockClient.Builder setUserClass(Class<T> userClass) {
+            this.userClass = userClass;
+            return this;
+        }
+
+        @Override
+        public MockClient<T> build() {
+            MockClient<T> client = new MockClient<>(new MockHttpTransport(), getHttpRequestInitializer(), getBaseUrl(), getServicePath(),
                     getObjectParser(), new MockKinveyClientRequestInitializer(), null, null, null, context);
+            client.setUserClass(userClass != null ? userClass : (Class<T>) User.class);
+            return client;
         }
 
     }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockClient.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockClient.java
@@ -44,6 +44,13 @@ public class MockClient<T extends User> extends Client<T> {
             return client;
         }
 
+        public MockClient<T> build(HttpTransport transport) {
+            MockClient<T> client = new MockClient<>(transport, getHttpRequestInitializer(), getBaseUrl(), getServicePath(),
+                    getObjectParser(), new MockKinveyClientRequestInitializer(), null, null, null, context);
+            client.setUserClass(userClass != null ? userClass : (Class<T>) User.class);
+            return client;
+        }
+
     }
 
     static class MockKinveyClientRequestInitializer extends KinveyClientRequestInitializer {

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockClient.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockClient.java
@@ -48,6 +48,7 @@ public class MockClient<T extends User> extends Client<T> {
             MockClient<T> client = new MockClient<>(transport, getHttpRequestInitializer(), getBaseUrl(), getServicePath(),
                     getObjectParser(), new MockKinveyClientRequestInitializer(), null, null, null, context);
             client.setUserClass(userClass != null ? userClass : (Class<T>) User.class);
+            initUserFromCredentialStore(client);
             return client;
         }
 

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockHttpErrorTransport.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockHttpErrorTransport.java
@@ -1,0 +1,67 @@
+package com.kinvey.androidTest.store.user;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.LowLevelHttpRequest;
+import com.google.api.client.http.LowLevelHttpResponse;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.Json;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.gson.Gson;
+import com.kinvey.android.model.User;
+
+public class MockHttpErrorTransport extends HttpTransport {
+
+    @Override
+    public LowLevelHttpRequest buildRequest(String method, final String url) {
+
+        return new MockLowLevelHttpRequest() {
+            @Override
+            public LowLevelHttpResponse execute() {
+
+                if (url.contains("oauth/token")) {
+                    return oauthToken();
+                } else if (url.contains("oauth/auth")) {
+                    return oauthAuth();
+                } else if (url.contains("tempURL")) {
+                    return tempURL();
+                } else if (url.contains("/login")) {
+                    return userLoginError();
+                }
+                return null;
+            }
+        };
+    }
+
+    private LowLevelHttpResponse oauthToken() {
+        MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+        GenericJson content = new GenericJson();
+        content.put("access_token", "myAccess");
+        content.put("refresh_token", "myRefresh");
+        content.put("token_type", "bearer");
+        content.put("expires_in", "100");
+        response.setContentType(Json.MEDIA_TYPE);
+        response.setContent(new Gson().toJson(content));
+        response.setStatusCode(200);
+        return response;
+    }
+
+    private MockLowLevelHttpResponse oauthAuth() {
+        return null;
+    }
+
+    private MockLowLevelHttpResponse tempURL() {
+        return null;
+    }
+
+    private  MockLowLevelHttpResponse userLoginError() {
+        MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+        GenericJson content = new GenericJson();
+        content.put("_id", "123");
+        response.setContentType(Json.MEDIA_TYPE);
+        response.setContent(new Gson().toJson(content));
+        response.setStatusCode(500);
+        return response;
+    }
+
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockHttpErrorTransport.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockHttpErrorTransport.java
@@ -12,6 +12,9 @@ import com.kinvey.android.model.User;
 
 public class MockHttpErrorTransport extends HttpTransport {
 
+    static final String ERROR_500 = "KinveyInternalErrorRetry";
+    static final String DESCRIPTION_500 = "The Kinvey server encountered an unexpected error. Please retry your request";
+
     @Override
     public LowLevelHttpRequest buildRequest(String method, final String url) {
 
@@ -27,6 +30,8 @@ public class MockHttpErrorTransport extends HttpTransport {
                     return tempURL();
                 } else if (url.contains("/login")) {
                     return userLoginError();
+                } else if (url.contains("/user/")) {
+                    return userRetrieve();
                 }
                 return null;
             }
@@ -57,7 +62,19 @@ public class MockHttpErrorTransport extends HttpTransport {
     private  MockLowLevelHttpResponse userLoginError() {
         MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
         GenericJson content = new GenericJson();
-        content.put("_id", "123");
+        content.put("error", ERROR_500);
+        content.put("description", DESCRIPTION_500);
+        response.setContentType(Json.MEDIA_TYPE);
+        response.setContent(new Gson().toJson(content));
+        response.setStatusCode(500);
+        return response;
+    }
+
+    private  MockLowLevelHttpResponse userRetrieve() {
+        MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+        User content = new User();
+        content.put("error", ERROR_500);
+        content.put("description", DESCRIPTION_500);
         response.setContentType(Json.MEDIA_TYPE);
         response.setContent(new Gson().toJson(content));
         response.setStatusCode(500);

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockHttpTransport.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockHttpTransport.java
@@ -27,7 +27,7 @@ public class MockHttpTransport extends HttpTransport {
                     return tempURL();
                 } else if (url.contains("/login")) {
                     return userLogin();
-                } else if (url.contains("/user/appkey/")) {
+                } else if (url.contains("/user/")) {
                     return userRetrieve();
                 }
                 return null;

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockHttpTransport.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockHttpTransport.java
@@ -8,6 +8,7 @@ import com.google.api.client.json.Json;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.gson.Gson;
+import com.kinvey.android.model.User;
 
 public class MockHttpTransport extends HttpTransport {
 
@@ -24,8 +25,10 @@ public class MockHttpTransport extends HttpTransport {
                     return oauthAuth();
                 } else if (url.contains("tempURL")) {
                     return tempURL();
-                }else if(url.contains("/login")){
+                } else if (url.contains("/login")) {
                     return userLogin();
+                } else if (url.contains("/user/appkey/")) {
+                    return userRetrieve();
                 }
                 return null;
             }
@@ -54,20 +57,23 @@ public class MockHttpTransport extends HttpTransport {
     }
 
     private  MockLowLevelHttpResponse userLogin() {
-
         MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
-
         GenericJson content = new GenericJson();
-
         content.put("_id", "123");
-
-
         response.setContentType(Json.MEDIA_TYPE);
-
         response.setContent(new Gson().toJson(content));
         response.setStatusCode(200);
+        return response;
+    }
 
-        return response;	}
-
+    private  MockLowLevelHttpResponse userRetrieve() {
+        MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+        User content = new User();
+        content.put("_id", "123");
+        response.setContentType(Json.MEDIA_TYPE);
+        response.setContent(new Gson().toJson(content));
+        response.setStatusCode(200);
+        return response;
+    }
 
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockHttpTransport.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockHttpTransport.java
@@ -1,0 +1,73 @@
+package com.kinvey.androidTest.store.user;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.LowLevelHttpRequest;
+import com.google.api.client.http.LowLevelHttpResponse;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.Json;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.gson.Gson;
+
+public class MockHttpTransport extends HttpTransport {
+
+    @Override
+    public LowLevelHttpRequest buildRequest(String method, final String url) {
+
+        return new MockLowLevelHttpRequest() {
+            @Override
+            public LowLevelHttpResponse execute() {
+
+                if (url.contains("oauth/token")) {
+                    return oauthToken();
+                } else if (url.contains("oauth/auth")) {
+                    return oauthAuth();
+                } else if (url.contains("tempURL")) {
+                    return tempURL();
+                }else if(url.contains("/login")){
+                    return userLogin();
+                }
+                return null;
+            }
+        };
+    }
+
+    private LowLevelHttpResponse oauthToken() {
+        MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+        GenericJson content = new GenericJson();
+        content.put("access_token", "myAccess");
+        content.put("refresh_token", "myRefresh");
+        content.put("token_type", "bearer");
+        content.put("expires_in", "100");
+        response.setContentType(Json.MEDIA_TYPE);
+        response.setContent(new Gson().toJson(content));
+        response.setStatusCode(200);
+        return response;
+    }
+
+    private MockLowLevelHttpResponse oauthAuth() {
+        return null;
+    }
+
+    private MockLowLevelHttpResponse tempURL() {
+        return null;
+    }
+
+    private  MockLowLevelHttpResponse userLogin() {
+
+        MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+
+        GenericJson content = new GenericJson();
+
+        content.put("_id", "123");
+
+
+        response.setContentType(Json.MEDIA_TYPE);
+
+        response.setContent(new Gson().toJson(content));
+        response.setStatusCode(200);
+
+        return response;	}
+
+
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockedClient.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/MockedClient.java
@@ -1,0 +1,54 @@
+package com.kinvey.androidTest.store.user;
+
+import android.content.Context;
+
+import com.google.api.client.http.BackOffPolicy;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonObjectParser;
+import com.kinvey.android.Client;
+import com.kinvey.android.model.User;
+import com.kinvey.java.auth.CredentialStore;
+import com.kinvey.java.core.AbstractKinveyClientRequest;
+import com.kinvey.java.core.KinveyClientRequestInitializer;
+import com.kinvey.java.core.KinveyHeaders;
+
+public class MockedClient<T extends User> extends Client<T> {
+
+
+    private MockedClient(HttpTransport transport, HttpRequestInitializer httpRequestInitializer, String rootUrl, String servicePath, JsonObjectParser objectParser, KinveyClientRequestInitializer kinveyRequestInitializer, CredentialStore store, BackOffPolicy requestPolicy, byte[] encryptionKey, Context context) {
+        super(transport, httpRequestInitializer, rootUrl, servicePath, objectParser, kinveyRequestInitializer, store, requestPolicy, encryptionKey, context);
+    }
+
+    public static class Builder<T extends User> extends Client.Builder {
+
+        Context context;
+
+        public Builder(Context context) {
+            super(context);
+            this.context = context;
+        }
+
+        @Override
+        public MockedClient build() {
+            return new MockedClient(new MockHttpTransport(), getHttpRequestInitializer(), getBaseUrl(), getServicePath(),
+                    getObjectParser(), new MockKinveyClientRequestInitializer(), null, null, null, context);
+        }
+
+    }
+
+    static class MockKinveyClientRequestInitializer extends KinveyClientRequestInitializer {
+
+        boolean isCalled;
+
+        MockKinveyClientRequestInitializer() {
+            super("appkey", "appsecret", new KinveyHeaders());
+        }
+
+        @Override
+        public void initialize(AbstractKinveyClientRequest<?> request) {
+            isCalled = true;
+        }
+    }
+
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/UserStoreMockTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/UserStoreMockTest.java
@@ -1,0 +1,81 @@
+package com.kinvey.androidTest.store.user;
+
+import android.content.Context;
+import android.os.Message;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.kinvey.android.Client;
+import com.kinvey.android.model.User;
+import com.kinvey.android.store.UserStore;
+import com.kinvey.androidTest.LooperThread;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+
+import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class UserStoreMockTest {
+
+    private Client client = null;
+    private Context mMockContext = null;
+
+    @Before
+    public void setup() {
+        if (mMockContext == null) {
+            mMockContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        }
+        client = new Client.Builder(mMockContext).build();
+//        client.enableDebugLogging();
+        if (client.isUserLoggedIn()) {
+//            logout(client);
+        }
+    }
+
+    @After
+    public void tearDown() {
+        client.performLockDown();
+        if (client.getKinveyHandlerThread() != null) {
+            try {
+                client.stopKinveyHandlerThread();
+            } catch (Throwable throwable) {
+                throwable.printStackTrace();
+            }
+        }
+    }
+
+    @Test
+    public void testLogin() throws InterruptedException {
+        Context mMockContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        MockClient<User> mockedClient = new MockClient.Builder<>(mMockContext).build();
+        DefaultKinveyClientCallback callback = login(mockedClient);
+        assertNull(callback.error);
+        assertNotNull(callback.result);
+    }
+
+    private DefaultKinveyClientCallback login(final Client client) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final DefaultKinveyClientCallback callback = new DefaultKinveyClientCallback(latch);
+        LooperThread looperThread = new LooperThread(() -> {
+            try {
+                UserStore.login(client, callback);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        });
+        looperThread.start();
+        latch.await();
+        looperThread.mHandler.sendMessage(new Message());
+        return callback;
+    }
+
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/UserStoreMockTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/UserStoreMockTest.java
@@ -13,6 +13,7 @@ import com.kinvey.androidTest.LooperThread;
 import com.kinvey.java.core.KinveyJsonResponseException;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +23,8 @@ import java.util.concurrent.CountDownLatch;
 
 import static com.kinvey.androidTest.TestManager.PASSWORD;
 import static com.kinvey.androidTest.TestManager.USERNAME;
+import static com.kinvey.androidTest.store.user.MockHttpErrorTransport.DESCRIPTION_500;
+import static com.kinvey.androidTest.store.user.MockHttpErrorTransport.ERROR_500;
 import static junit.framework.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -34,17 +37,23 @@ public class UserStoreMockTest {
     private Context mMockContext = null;
 
     @Before
-    public void setup() {
+    public void setup() throws InterruptedException {
         if (mMockContext == null) {
             mMockContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         }
         if (client == null) {
             client = new Client.Builder(mMockContext).build();
         }
+        if (client.isUserLoggedIn()) {
+            logout(client);
+        }
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws InterruptedException {
+        if (client.isUserLoggedIn()) {
+            logout(client);
+        }
         client.performLockDown();
         if (client.getKinveyHandlerThread() != null) {
             try {
@@ -80,6 +89,34 @@ public class UserStoreMockTest {
         assertEquals(500, ((KinveyJsonResponseException) callback.error).getStatusCode());
     }
 
+    @Test
+    public void testLoginError500() throws InterruptedException {
+        MockClient<User> mockedClient = new MockClient.Builder<>(mMockContext).build(new MockHttpErrorTransport());
+        DefaultKinveyClientCallback callback = login(USERNAME, PASSWORD, mockedClient);
+        assertNotNull(callback.error);
+        assertNull(callback.result);
+        assertEquals(500, ((KinveyJsonResponseException) callback.error).getStatusCode());
+        assertEquals(ERROR_500+"\n"+DESCRIPTION_500, callback.error.getMessage());
+    }
+
+    @Test
+    public void testLoginWithCredentialsError() throws InterruptedException {
+        login(USERNAME, PASSWORD, client); //to save login and password to Credential
+        Assert.assertTrue(client.isUserLoggedIn());
+        MockClient<User> mockedClient = new MockClient.Builder<>(mMockContext).build(new MockHttpErrorTransport());
+        Assert.assertFalse(mockedClient.isUserLoggedIn());
+    }
+
+    @Test
+    public void testLoginWithCredentials() throws InterruptedException {
+        if (!client.isUserLoggedIn()) {
+            login(USERNAME, PASSWORD, client); //to save login and password to Credential
+        }
+        Assert.assertTrue(client.isUserLoggedIn());
+        MockClient<User> mockedClient = new MockClient.Builder<>(mMockContext).build(new MockHttpTransport());
+        Assert.assertTrue(mockedClient.isUserLoggedIn());
+    }
+
     private DefaultKinveyClientCallback login(final Client client) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final DefaultKinveyClientCallback callback = new DefaultKinveyClientCallback(latch);
@@ -106,6 +143,16 @@ public class UserStoreMockTest {
                 e.printStackTrace();
             }
         });
+        looperThread.start();
+        latch.await();
+        looperThread.mHandler.sendMessage(new Message());
+        return callback;
+    }
+
+    private DefaultKinveyVoidCallback logout(final Client client) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final DefaultKinveyVoidCallback callback = new DefaultKinveyVoidCallback(latch);
+        LooperThread looperThread = new LooperThread(() -> UserStore.logout(client, callback));
         looperThread.start();
         latch.await();
         looperThread.mHandler.sendMessage(new Message());

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/UserStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/UserStoreTest.java
@@ -180,33 +180,6 @@ public class UserStoreTest {
         }
     }
 
-    private static class DefaultKinveyVoidCallback implements KinveyClientCallback<Void> {
-
-        private CountDownLatch latch;
-        private Void result;
-        private Throwable error;
-
-        private DefaultKinveyVoidCallback(CountDownLatch latch) {
-            this.latch = latch;
-        }
-
-        @Override
-        public void onSuccess(Void result) {
-            this.result = result;
-            finish();
-        }
-
-        @Override
-        public void onFailure(Throwable error) {
-            this.error = error;
-            finish();
-        }
-
-        private void finish() {
-            latch.countDown();
-        }
-    }
-
     private static class UserGroupResponseCallback implements KinveyClientCallback<UserGroup.UserGroupResponse> {
 
         private CountDownLatch latch;

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/UserStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/UserStoreTest.java
@@ -73,33 +73,6 @@ public class UserStoreTest {
     public static final String INSUFFICIENT_CREDENTIAL_TYPE = "InsufficientCredentials";
     private static final String ACTIVE_USER_COLLECTION_NAME = "active_user_info";
 
-    private static class DefaultKinveyClientCallback implements KinveyClientCallback<User> {
-
-        private CountDownLatch latch;
-        private User result;
-        private Throwable error;
-
-        private DefaultKinveyClientCallback(CountDownLatch latch) {
-            this.latch = latch;
-        }
-
-        @Override
-        public void onSuccess(User user) {
-            this.result = user;
-            finish();
-        }
-
-        @Override
-        public void onFailure(Throwable error) {
-            this.error = error;
-            finish();
-        }
-
-        private void finish() {
-            latch.countDown();
-        }
-    }
-
     private static class DefaultKinveyUserListCallback implements KinveyUserListCallback {
 
         private CountDownLatch latch;
@@ -489,7 +462,7 @@ public class UserStoreTest {
 
     private DefaultKinveyClientCallback get(final String userName) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
-        final UserStoreTest.DefaultKinveyClientCallback callback = new UserStoreTest.DefaultKinveyClientCallback(latch);
+        final DefaultKinveyClientCallback callback = new DefaultKinveyClientCallback(latch);
         LooperThread looperThread = new LooperThread(new Runnable() {
             @Override
             public void run() {
@@ -546,7 +519,7 @@ public class UserStoreTest {
 
     private DefaultKinveyClientCallback login(final String userName, final String password) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
-        final UserStoreTest.DefaultKinveyClientCallback callback = new UserStoreTest.DefaultKinveyClientCallback(latch);
+        final DefaultKinveyClientCallback callback = new DefaultKinveyClientCallback(latch);
         LooperThread looperThread = new LooperThread(new Runnable() {
             @Override
             public void run() {
@@ -565,7 +538,7 @@ public class UserStoreTest {
 
     private DefaultKinveyClientCallback signUp() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
-        final UserStoreTest.DefaultKinveyClientCallback callback = new UserStoreTest.DefaultKinveyClientCallback(latch);
+        final DefaultKinveyClientCallback callback = new DefaultKinveyClientCallback(latch);
         LooperThread looperThread = new LooperThread(new Runnable() {
             @Override
             public void run() {
@@ -580,7 +553,7 @@ public class UserStoreTest {
 
     private CustomKinveyClientCallback signUp(final TestUser user) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
-        final UserStoreTest.CustomKinveyClientCallback callback = new UserStoreTest.CustomKinveyClientCallback(latch);
+        final CustomKinveyClientCallback callback = new CustomKinveyClientCallback(latch);
         LooperThread looperThread = new LooperThread(new Runnable() {
             @Override
             public void run() {
@@ -1937,16 +1910,6 @@ public class UserStoreTest {
         assertNull(((Map<String, String>) user.get(KMD)).get(AUTH_TOKEN)); // check that realm doesn't keep auth_token
         assertNotNull(((Map<String, String>) client.getActiveUser().get(KMD)).get(AUTH_TOKEN)); // check that active user has auth_token
         assertNull(logout(client).error);
-    }
-
-    @Test
-    public void testLoginError() throws InterruptedException {
-        Context mMockContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
-        MockedClient<User> mockedClient = new MockedClient.Builder<>(mMockContext).build();
-        DefaultKinveyClientCallback callback = login(mockedClient);
-        assertTrue(mockedClient.isUserLoggedIn());
-
-
     }
 
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/UserStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/UserStoreTest.java
@@ -619,14 +619,11 @@ public class UserStoreTest {
     private DefaultKinveyClientCallback login(final Client client) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final DefaultKinveyClientCallback callback = new DefaultKinveyClientCallback(latch);
-        LooperThread looperThread = new LooperThread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    UserStore.login(client, callback);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
+        LooperThread looperThread = new LooperThread(() -> {
+            try {
+                UserStore.login(client, callback);
+            } catch (IOException e) {
+                e.printStackTrace();
             }
         });
         looperThread.start();
@@ -1940,6 +1937,16 @@ public class UserStoreTest {
         assertNull(((Map<String, String>) user.get(KMD)).get(AUTH_TOKEN)); // check that realm doesn't keep auth_token
         assertNotNull(((Map<String, String>) client.getActiveUser().get(KMD)).get(AUTH_TOKEN)); // check that active user has auth_token
         assertNull(logout(client).error);
+    }
+
+    @Test
+    public void testLoginError() throws InterruptedException {
+        Context mMockContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        MockedClient<User> mockedClient = new MockedClient.Builder<>(mMockContext).build();
+        DefaultKinveyClientCallback callback = login(mockedClient);
+        assertTrue(mockedClient.isUserLoggedIn());
+
+
     }
 
 }

--- a/android-lib/src/main/java/com/kinvey/android/Client.java
+++ b/android-lib/src/main/java/com/kinvey/android/Client.java
@@ -897,21 +897,7 @@ public class Client<T extends User> extends AbstractClient<T> {
             if (!Strings.isNullOrEmpty(this.instanceID)) {
                 client.setMICHostName(Constants.PROTOCOL_HTTPS + instanceID + Constants.HYPHEN + Constants.HOSTNAME_AUTH);
             }
-            try {
-                Credential credential = retrieveUserFromCredentialStore(client);
-                if (credential != null) {
-                    loginWithCredential(client, credential);
-                }
-
-            } catch (AndroidCredentialStoreException ex) {
-                Logger.ERROR("Credential store was in a corrupted state and had to be rebuilt");
-                client.setActiveUser(null);
-            } catch (IOException ex) {
-                Logger.ERROR("Credential store failed to load");
-                client.setActiveUser(null);
-            }
-
-
+            initUserFromCredentialStore(client);
             return client;
         }
 
@@ -928,6 +914,20 @@ public class Client<T extends User> extends AbstractClient<T> {
             new Build(buildCallback).execute();
         }
 
+        protected void initUserFromCredentialStore(Client client) {
+            try {
+                Credential credential = retrieveUserFromCredentialStore(client);
+                if (credential != null) {
+                    loginWithCredential(client, credential);
+                }
+            } catch (AndroidCredentialStoreException ex) {
+                Logger.ERROR("Credential store was in a corrupted state and had to be rebuilt");
+                client.setActiveUser(null);
+            } catch (IOException ex) {
+                Logger.ERROR("Credential store failed to load");
+                client.setActiveUser(null);
+            }
+        }
 
         /**
          * Define how credentials will be stored

--- a/android-lib/src/main/java/com/kinvey/android/store/UserStore.java
+++ b/android-lib/src/main/java/com/kinvey/android/store/UserStore.java
@@ -1111,7 +1111,7 @@ public class UserStore {
 
         @Override
         protected T executeAsync() throws IOException {
-            UserStoreRequestManager requestManager = new UserStoreRequestManager(client, createBuilder(client));
+            UserStoreRequestManager requestManager = new UserStoreRequestManager<>(client, createBuilder(client));
             requestManager.setMICRedirectURI(redirectURI);
             GenericJson result = requestManager.getMICToken(token, clientId).execute();
 
@@ -1147,7 +1147,7 @@ public class UserStore {
 
         @Override
         protected T executeAsync() throws IOException {
-            UserStoreRequestManager requestManager = new UserStoreRequestManager(client, createBuilder(client));
+            UserStoreRequestManager requestManager = new UserStoreRequestManager<>(client, createBuilder(client));
             requestManager.setMICRedirectURI(redirectURI);
             GenericJson result = requestManager.getOAuthToken(clientId, username, password).execute();
             T ret =  BaseUserStore.loginMobileIdentity(result.get(ACCESS_TOKEN).toString(), client);


### PR DESCRIPTION
#### Description
Create mock responses to simulate user and login server errors (5xx).

#### Changes
Added `MockClient` for mocking server responses for `UserStoreMockTest`. 
Checked that user logs out when the client object is initialising if the SDK gets HttpResponseException.
Checked that user gets in callback status code and error messages. 

#### Tests
Instrumented
