### PR TITLE
MLIBZ-3137: In a batch of multi-insert requests, if a whole batch fails, the response to the whole operation is an error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,9 +73,9 @@ install:
 #  - android-wait-for-emulator
 #  - adb shell input keyevent 82 &
 #  - ./gradlew --stop
-script: 
-  - ./gradlew clean release --no-daemon 
-  - travis_wait 60 ./gradlew connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.package=com.kinvey.androidTest.$PACKAGE -PdisablePreDex --stacktrace --no-daemon
+script:
+  - ./gradlew clean release --no-daemon
+  - travis_wait 90 ./gradlew connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.package=com.kinvey.androidTest.$PACKAGE -PdisablePreDex --stacktrace --no-daemon
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -t $CODECOV_GIT_TOKEN

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/BaseDataStoreTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/BaseDataStoreTest.kt
@@ -350,15 +350,26 @@ open class BaseDataStoreTest {
     }
 
     // create an array with a few items that have _id property or have not.
-    fun createPersonsList(count: Int, withId: Boolean): List<Person> {
+    fun createPersonsList(count: Int, error: Boolean = false, withId: Boolean = false): List<Person> {
         return 1.rangeTo(count).map { i ->
             val person = createPerson(TEST_USERNAME + i.toString())
             if (withId) {
                 val id = "123456$i"
                 person.id = id
             }
+            if (error) {
+                person.geoloc = ERR_GEOLOC
+            }
             person
         }
+    }
+
+    // create an array with a few items that have _id property or have not.
+    fun createPersonsListErr(count: Int, errCount: Int, errPos: Int = count): List<Person> {
+        val items = createPersonsList(count, error = false, withId = false)
+        val itemsErr = createPersonsList(errCount, error = true, withId = false)
+        (items as MutableList).addAll(errPos, itemsErr)
+        return items
     }
 
     fun createPersonsList(withId: Boolean): List<Person> {

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/BaseDataStoreTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/BaseDataStoreTest.kt
@@ -18,6 +18,7 @@ import com.kinvey.androidTest.model.EntitySet
 import com.kinvey.androidTest.model.Person
 import com.kinvey.androidTest.network.MockMultiInsertNetworkManager
 import com.kinvey.java.*
+import com.kinvey.java.AbstractClient.Companion.kinveyApiVersion
 import com.kinvey.java.core.AbstractKinveyClient
 import com.kinvey.java.core.KinveyClientCallback
 import com.kinvey.java.model.KinveyBatchInsertError
@@ -54,12 +55,13 @@ open class BaseDataStoreTest {
     @Throws(InterruptedException::class, IOException::class)
     fun setUp() {
         val mMockContext = InstrumentationRegistry.getInstrumentation().targetContext
+        kinveyApiVersion = "5"
         client = Client.Builder<User>(mMockContext).build()
         client.enableDebugLogging()
-        AbstractClient.kinveyApiVersion = "5"
+        kinveyApiVersion = "5"
         val latch = CountDownLatch(1)
         var looperThread: LooperThread? = null
-        if (client.isUserLoggedIn == false) {
+        if (!client.isUserLoggedIn) {
             looperThread = LooperThread(Runnable {
                 try {
                     UserStore.login(TestManager.USERNAME, TestManager.PASSWORD, client as Client<User>, object : KinveyClientCallback<User> {

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultiInsertItemsOrderTestKotlin.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultiInsertItemsOrderTestKotlin.kt
@@ -12,7 +12,6 @@ import org.junit.runner.RunWith
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Ignore
 
 @RunWith(AndroidJUnit4::class)
 @SmallTest

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultiInsertTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultiInsertTest.java
@@ -75,6 +75,7 @@ public class DataStoreMultiInsertTest {
     @Before
     public void setUp() throws InterruptedException, IOException {
         Context mMockContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        AbstractClient.setKinveyApiVersion("5");
         client = new Client.Builder(mMockContext).build();
         client.enableDebugLogging();
         AbstractClient.setKinveyApiVersion("5");

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultiInsertTestKotlin.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultiInsertTestKotlin.kt
@@ -1296,4 +1296,22 @@ class DataStoreMultiInsertTestKotlin : BaseDataStoreTest() {
 
         assertEquals(netManager.multiPostCount, 2)
     }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testSaveMultipleBatchRequestsIfWasErrors() {
+        print("should send multiple multi-insert POST requests, if was errors then should return empty array and array of errors")
+        val netManager = MockMultiInsertNetworkManager(Person.COLLECTION, Person::class.java, client as Client)
+        val store = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.NETWORK, netManager)
+        clearBackend(store)
+        client?.syncManager?.clear(Person.COLLECTION)
+
+        val itemsList = createPersonsList(200, false)
+
+        val saveCallback = saveList(store, itemsList)
+        assertNotNull(saveCallback.result)
+        assertNull(saveCallback.error)
+
+        assertEquals(netManager.multiPostCount, 2)
+    }
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultiInsertTestKotlin.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultiInsertTestKotlin.kt
@@ -1278,40 +1278,4 @@ class DataStoreMultiInsertTestKotlin : BaseDataStoreTest() {
         // find using syncstore, should return all items including the invalid one
         testSyncItemsList(true, StoreType.AUTO)
     }
-
-    @Test
-    @Throws(InterruptedException::class)
-    fun testSaveMultipleBatchRequests() {
-        print("should send multiple multi-insert POST requests")
-        val netManager = MockMultiInsertNetworkManager(Person.COLLECTION, Person::class.java, client as Client)
-        val store = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.NETWORK, netManager)
-        clearBackend(store)
-        client?.syncManager?.clear(Person.COLLECTION)
-
-        val itemsList = createPersonsList(200, false)
-
-        val saveCallback = saveList(store, itemsList)
-        assertNotNull(saveCallback.result)
-        assertNull(saveCallback.error)
-
-        assertEquals(netManager.multiPostCount, 2)
-    }
-
-    @Test
-    @Throws(InterruptedException::class)
-    fun testSaveMultipleBatchRequestsIfWasErrors() {
-        print("should send multiple multi-insert POST requests, if was errors then should return empty array and array of errors")
-        val netManager = MockMultiInsertNetworkManager(Person.COLLECTION, Person::class.java, client as Client)
-        val store = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.NETWORK, netManager)
-        clearBackend(store)
-        client?.syncManager?.clear(Person.COLLECTION)
-
-        val itemsList = createPersonsList(200, false)
-
-        val saveCallback = saveList(store, itemsList)
-        assertNotNull(saveCallback.result)
-        assertNull(saveCallback.error)
-
-        assertEquals(netManager.multiPostCount, 2)
-    }
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultiInsertTestOrderKotlin.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultiInsertTestOrderKotlin.kt
@@ -16,7 +16,6 @@ import org.junit.Ignore
 
 @RunWith(AndroidJUnit4::class)
 @SmallTest
-@Ignore("Ignored tests in Kotlin for now while Kotlin migration is not done")
 class DataStoreMultiInsertItemsOrderTestKotlin : BaseDataStoreTest() {
 
     @Test

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultipleMultiInsertTestKotlin.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultipleMultiInsertTestKotlin.kt
@@ -1,0 +1,56 @@
+package com.kinvey.androidTest.store.datastore
+
+import androidx.test.filters.SmallTest
+import androidx.test.runner.AndroidJUnit4
+import com.kinvey.android.store.DataStore
+import com.kinvey.androidTest.model.Person
+import com.kinvey.androidTest.network.MockMultiInsertNetworkManager
+import com.kinvey.java.store.StoreType
+import org.junit.Assert
+
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Ignore
+
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+class DataStoreMultipleMultiInsertTestKotlin : BaseDataStoreTest() {
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testSaveMultipleBatchRequests() {
+        print("should send multiple multi-insert POST requests")
+        val netManager = MockMultiInsertNetworkManager(Person.COLLECTION, Person::class.java, client)
+        val store = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.NETWORK, netManager)
+        clearBackend(store)
+        client.syncManager.clear(Person.COLLECTION)
+
+        val itemsList = createPersonsList(200, false)
+
+        val saveCallback = saveList(store, itemsList)
+        assertNotNull(saveCallback.result)
+        assertNull(saveCallback.error)
+
+        Assert.assertEquals(netManager.multiPostCount, 2)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testSaveMultipleBatchRequestsIfWasErrors() {
+        print("should send multiple multi-insert POST requests, if was errors then should return empty array and array of errors")
+        val netManager = MockMultiInsertNetworkManager(Person.COLLECTION, Person::class.java, client)
+        val store = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.NETWORK, netManager)
+        clearBackend(store)
+        client.syncManager.clear(Person.COLLECTION)
+        val itemsList = createPersonsListErr(200, 50, 50)
+        val saveCallback = saveList(store, itemsList)
+        assertNotNull(saveCallback.result)
+        assertNull(saveCallback.error)
+
+        Assert.assertEquals(netManager.multiPostCount, 3)
+    }
+}

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
@@ -119,7 +119,7 @@ open class DataStore<T : GenericJson> : BaseDataStore<T> {
 
     private val kinveyApiVersion: Int
         get() {
-            var version = 0
+            var version = DEFAULT_KINVEY_API_VERSION
             try {
                 val versionStr = AbstractClient.kinveyApiVersion
                 if (versionStr.isNotEmpty()) {
@@ -1152,6 +1152,8 @@ open class DataStore<T : GenericJson> : BaseDataStore<T> {
         private val KEY_UNSUBSCRIBE = "KEY_UNSUBSCRIBE"
 
         private val KINVEY_API_VERSION_5 = 5
+
+        private const val DEFAULT_KINVEY_API_VERSION = 4
 
         /*private static final String KEY_GET_BY_ID_WITH_REFERENCES = "KEY_GET_BY_ID_WITH_REFERENCES";
     private static final String KEY_GET_QUERY_WITH_REFERENCES = "KEY_GET_QUERY_WITH_REFERENCES";

--- a/java-api-core/src/com/kinvey/java/AbstractClient.kt
+++ b/java-api-core/src/com/kinvey/java/AbstractClient.kt
@@ -25,14 +25,11 @@ import com.google.api.client.util.GenericData
 
 import java.io.IOException
 import java.lang.reflect.Array
-import java.net.URL
-import java.util.ArrayList
 import java.util.Properties
 import java.util.logging.Level
 import java.util.logging.Logger
 
 import com.kinvey.java.auth.ClientUser
-import com.kinvey.java.auth.Credential
 import com.kinvey.java.auth.CredentialManager
 import com.kinvey.java.auth.CredentialStore
 import com.kinvey.java.cache.ICacheManager
@@ -42,7 +39,6 @@ import com.kinvey.java.core.KinveyClientRequestInitializer
 import com.kinvey.java.dto.BaseUser
 import com.kinvey.java.network.NetworkFileManager
 import com.kinvey.java.query.MongoQueryFilter
-import com.kinvey.java.store.BaseDataStore
 import com.kinvey.java.store.BaseFileStore
 import com.kinvey.java.store.StoreType
 import com.kinvey.java.sync.SyncManager
@@ -196,7 +192,6 @@ protected constructor(transport: HttpTransport?,
     init {
         sharedInstance = this
         this.user = null
-        KINVEY_API_VERSION = ""
     }
 
     fun query(): Query {
@@ -508,17 +503,7 @@ protected constructor(transport: HttpTransport?,
         /**
          * Non-default version of API. Developer should initialize it for change API version
          */
-        private lateinit var KINVEY_API_VERSION: String
-        @JvmStatic var kinveyApiVersion: String
-            get() {
-                if (!::KINVEY_API_VERSION.isInitialized) {
-                    KINVEY_API_VERSION = ""
-                }
-                return KINVEY_API_VERSION
-            }
-            set(value) {
-                KINVEY_API_VERSION = value
-            }
+        @JvmStatic var kinveyApiVersion: String = ""
 
         @JvmStatic
         var sharedInstance: AbstractClient<*>? = null

--- a/java-api-core/src/com/kinvey/java/store/requests/data/save/SaveListBatchRequest.kt
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/save/SaveListBatchRequest.kt
@@ -49,6 +49,7 @@ class SaveListBatchRequest<T : GenericJson>(
     private var saveList: MutableList<T>? = null
     private var exception: KinveySaveBatchException? = null
     private var wasException = false
+    private var multipleRequests = false
 
     private val MAX_POST_ITEMS = 100
 
@@ -62,15 +63,15 @@ class SaveListBatchRequest<T : GenericJson>(
             }
             WritePolicy.LOCAL_THEN_NETWORK -> {
                 doPushRequest()
-                cache?.save(objects)
-                retList = runSaveItemsRequest(objects)
+                val itemsToSend = cache?.save(objects)
+                retList = runSaveItemsRequest(itemsToSend as List<T>)
                 cache?.save(retList)
                 if (exception is IOException) {
                     throw exception as IOException
                 }
             }
             WritePolicy.FORCE_NETWORK -> {
-                retList = runSaveItemsRequest(objects)
+                retList = runSaveItemsRequest(objects as List<T>, false)
                 if (exception is IOException) {
                     throw exception as IOException
                 }
@@ -80,17 +81,18 @@ class SaveListBatchRequest<T : GenericJson>(
     }
 
     @Throws(IOException::class)
-    private fun runSaveItemsRequest(objects: Iterable<T>): List<T> {
+    private fun runSaveItemsRequest(objects: List<T>, useCache: Boolean = true): List<T> {
         Logger.INFO("Start saving entities")
         filterObjects(objects as List<T>)
-        val postEntities = ArrayList<T>()
+        val postEntities = ArrayList<T?>()
         val batchSaveErrors = ArrayList<KinveyBatchInsertError>()
-
         val updateResponse = updateObjects(updateList)
         //updateResponse.entities?.let { list -> saveEntities.addAll(list) }
+        val count = saveList?.count() ?: 0
+        multipleRequests = count > MAX_POST_ITEMS
 
         if (saveList?.isNotEmpty() == true && saveList is List<T>) {
-            postBatchItems(saveList as List<T>, postEntities, batchSaveErrors)
+            postBatchItems(saveList as List<T>, postEntities, batchSaveErrors, useCache)
         }
         if (wasException) {
             exception = KinveySaveBatchException(batchSaveErrors, updateResponse.errors, postEntities)
@@ -101,24 +103,26 @@ class SaveListBatchRequest<T : GenericJson>(
         return resultItems
     }
 
-    private fun postBatchItems(entities: List<T>, batchSaveEntities: MutableList<T>, batchSaveErrors: MutableList<KinveyBatchInsertError>) {
+    private fun postBatchItems(entities: List<T>, batchSaveEntities: MutableList<T?>, batchSaveErrors: MutableList<KinveyBatchInsertError>, useCache: Boolean = true) {
         entities.chunked(MAX_POST_ITEMS).onEach { items ->
-            postSaveBatchRequest(items, batchSaveEntities, batchSaveErrors)
+            postSaveBatchRequest(items, batchSaveEntities, batchSaveErrors, useCache)
         }
     }
 
     @Throws(IOException::class)
     private fun postSaveBatchRequest(entities: List<T>,
-        batchSaveEntities: MutableList<T>, batchSaveErrors: MutableList<KinveyBatchInsertError>): KinveySaveBatchResponse<*>? {
+        batchSaveEntities: MutableList<T?>, batchSaveErrors: MutableList<KinveyBatchInsertError>, useCache: Boolean = true): KinveySaveBatchResponse<*>? {
         var response: KinveySaveBatchResponse<*>? = null
         try {
             val batchList = prepareSaveItems(SyncRequest.HttpVerb.POST, entities)
             response = networkManager.saveBatchBlocking(batchList).execute()
-        } catch (e: KinveyJsonResponseException) {
-            throw e
-        } catch (e: IOException) {
-            wasException = true
-            enqueueSaveRequests(entities, SyncRequest.HttpVerb.POST)
+        }
+        catch (e: KinveyJsonResponseException) {
+            if (!multipleRequests) throw e
+        }
+        catch (e: IOException) {
+            //wasException = true
+            if (useCache) { enqueueSaveRequests(entities, SyncRequest.HttpVerb.POST) }
         }
         if (response != null) {
             if (!response.haveErrors) {
@@ -129,15 +133,18 @@ class SaveListBatchRequest<T : GenericJson>(
                 enqueueBatchErrorsRequests(entities, response)
             }
             removeSuccessBatchItemsFromCache(entities, batchSaveErrors)
+        } else if (multipleRequests) {
+            val emptyList = listOf(*Array<Any?>(entities.count()) { GenericJson() })
+            batchSaveEntities.addAll(emptyList as List<T?>)
         }
         return response
     }
 
-    private fun recoverItemsOrder(srcItems: List<T>, postItems: List<T>, putItems: List<T>): List<T> {
+    private fun recoverItemsOrder(srcItems: List<T>, postItems: List<T?>, putItems: List<T?>): List<T> {
         var postIdx = 0
         var putIdx = 0
         if (srcItems.count() != postItems.count() + putItems.count()) {
-            return postItems + putItems
+            return postItems.filterNotNull() + putItems.filterNotNull()
         }
         return srcItems.mapNotNull { item ->
             if (item[_ID] != null

--- a/java-api-core/src/com/kinvey/java/store/requests/data/save/SaveListBatchRequest.kt
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/save/SaveListBatchRequest.kt
@@ -124,7 +124,7 @@ class SaveListBatchRequest<T : GenericJson>(
             if (!response.haveErrors) {
                 response.entities?.let { list -> batchSaveEntities.addAll(list as List<T>) }
             } else {
-                wasException = true
+                //wasException = true
                 response.errors?.let{ errors -> batchSaveErrors.addAll(errors) }
                 enqueueBatchErrorsRequests(entities, response)
             }


### PR DESCRIPTION
#### Description
Fix for issue if in a batch of multi-insert requests, if a whole batch fails, the response to the whole operation is an error.

#### Changes
Made fixes to solve issue if in a batch of multi-insert requests, if a whole batch fails, the response to the whole operation is an error.

#### Tests
Instrumented.
