### PR TITLE
MLIBZ-3140: datastore.save failing for network error invokes the onFailure handler - Android

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,12 +1,12 @@
 container:
-  image: cirrusci/android-sdk:24
+  image: cirrusci/android-sdk:27
   cpu: 4
   memory: 10G
 
 env:
   CI: "true"
   BUILD_TOOLS: "29.0.2"
-  ANDROID_API: "24"
+  ANDROID_API: "27"
   EMU_FLAVOR: default
   ANDROID_ABI: armeabi-v7a
   ADB_INSTALL_TIMEOUT: "10" # minutes

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,15 +1,15 @@
 container:
-  image: cirrusci/android-sdk:27
+  image: cirrusci/android-sdk:24
   cpu: 4
   memory: 10G
 
 env:
   CI: "true"
   BUILD_TOOLS: "29.0.2"
-  ANDROID_API: "27"
+  ANDROID_API: "24"
   EMU_FLAVOR: default
   ANDROID_ABI: armeabi-v7a
-  ADB_INSTALL_TIMEOUT: "10" # minutes
+  ADB_INSTALL_TIMEOUT: "20" # minutes
   KINVEY_APP_KEY: ENCRYPTED[8471c9d1a011d1632ad737a5686ce7e131384faabd193322f6c47e902e034ae8d329f4a1c05b7f0a6801d8332e1ee2d1]
   KINVEY_APP_SECRET: ENCRYPTED[122cdf1a7a68e55b0e39a81c10256708cdc0e317dd47af5f2724de52fea530d9f7ecc6907069b053a27ec80fa685ca7f]
 
@@ -67,8 +67,9 @@ task:
   # wait_for_emulator_script:
   #   - adb wait-for-device
   #   - adb shell input keyevent 82
-  wait_for_emulator_script: adb wait-for-device
+  #wait_for_emulator_script: adb wait-for-device
   # input_keyevent_script: adb shell input keyevent 82
+  wait_for_emulator_script: adb wait-for-device
   emulator_api_level_script: adb shell getprop ro.build.version.sdk
   emulator_boot_animation_script: while [ "`adb shell getprop init.svc.bootanim | tr -d '\r' `" != "stopped" ] ; do sleep 1; done
   emulator_bootanim_exit_script: while [ "`adb shell getprop service.bootanim.exit | tr -d '\r' `" != "1" ] ; do sleep 1; done

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultiInsertOfflinePushTestKotlin.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultiInsertOfflinePushTestKotlin.kt
@@ -33,7 +33,7 @@ class DataStoreMultiInsertOfflinePushTestKotlin : BaseDataStoreTest() {
         assertNotNull(syncItems)
         assertEquals(1, syncItems?.count())
 
-        assertNotNull(saveResult.error)
+        assertNull(saveResult.error)
         assertNotNull(pushResult.error)
     }
 
@@ -55,9 +55,6 @@ class DataStoreMultiInsertOfflinePushTestKotlin : BaseDataStoreTest() {
         val pushResult = push(autoStore, LONG_TIMEOUT)
         cancelMockInvalidConnection()
 
-        assertNotNull(saveResult.error)
-        assertNotNull(pushResult.error)
-
         val findResult = find(syncStore, LONG_TIMEOUT)
         assertNotNull(findResult.result)
         assertNull(findResult.error)
@@ -67,7 +64,29 @@ class DataStoreMultiInsertOfflinePushTestKotlin : BaseDataStoreTest() {
         assertNotNull(syncItems)
         assertEquals(1, syncItems?.count())
     
-        assertNotNull(saveResult.error)
+        assertNull(saveResult.error)
         assertNotNull(pushResult.error)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testSaveItemWithConnectivityErrorAuto() {
+        print("should save item in local cache")
+
+        val person = Person(TEST_USERNAME)
+        val autoStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.AUTO, client)
+        clearBackend(autoStore)
+        client.syncManager.clear(Person.COLLECTION)
+
+        mockInvalidConnection()
+        val saveResult = save(autoStore, person)
+        cancelMockInvalidConnection()
+
+        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        assertNotNull(syncItems)
+        assertEquals(1, syncItems?.count())
+
+        assertNotNull(saveResult.result)
+        assertNull(saveResult.error)
     }
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreTest.java
@@ -1463,8 +1463,8 @@ public class DataStoreTest {
     public void testSaveNoAccess() throws InterruptedException { //SAVE
         DataStore<EntitySet> storeAuto = DataStore.collection(EntitySet.COLLECTION, EntitySet.class, StoreType.AUTO, client);
         DefaultKinveyEntityCallback defaultKinveyEntityCallback  = saveEntitySet(storeAuto, new EntitySet());
-        assertNotNull(defaultKinveyEntityCallback.error);
-        assertEquals(defaultKinveyEntityCallback.error.getClass(), KinveyJsonResponseException.class);
+        assertNull(defaultKinveyEntityCallback.error);
+        //assertEquals(defaultKinveyEntityCallback.error.getClass(), KinveyJsonResponseException.class);
     }
 
     @Test
@@ -1476,7 +1476,7 @@ public class DataStoreTest {
         mockInvalidConnection();
         Person person = createPerson(TEST_USERNAME);
         DefaultKinveyClientCallback saveCallback = save(storeAuto, person);
-        assertNull(saveCallback.result);
+        assertNotNull(saveCallback.result);
         DefaultKinveyReadCallback findCallback = find(storeAuto, LONG_TIMEOUT);
         assertNotNull(findCallback.result);
         assertTrue(findCallback.result.getResult().size() == 1);

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreTest.java
@@ -1464,7 +1464,7 @@ public class DataStoreTest {
         DataStore<EntitySet> storeAuto = DataStore.collection(EntitySet.COLLECTION, EntitySet.class, StoreType.AUTO, client);
         DefaultKinveyEntityCallback defaultKinveyEntityCallback  = saveEntitySet(storeAuto, new EntitySet());
         assertNotNull(defaultKinveyEntityCallback.error);
-        assertEquals(defaultKinveyEntityCallback.error.getClass(), KinveyJsonResponseException.class);
+        //assertEquals(defaultKinveyEntityCallback.error.getClass(), KinveyJsonResponseException.class);
     }
 
     @Test

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreTest.java
@@ -1463,8 +1463,8 @@ public class DataStoreTest {
     public void testSaveNoAccess() throws InterruptedException { //SAVE
         DataStore<EntitySet> storeAuto = DataStore.collection(EntitySet.COLLECTION, EntitySet.class, StoreType.AUTO, client);
         DefaultKinveyEntityCallback defaultKinveyEntityCallback  = saveEntitySet(storeAuto, new EntitySet());
-        assertNull(defaultKinveyEntityCallback.error);
-        //assertEquals(defaultKinveyEntityCallback.error.getClass(), KinveyJsonResponseException.class);
+        assertNotNull(defaultKinveyEntityCallback.error);
+        assertEquals(defaultKinveyEntityCallback.error.getClass(), KinveyJsonResponseException.class);
     }
 
     @Test

--- a/java-api-core/src/com/kinvey/java/store/requests/data/save/SaveRequest.kt
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/save/SaveRequest.kt
@@ -71,12 +71,12 @@ class SaveRequest<T : GenericJson>(private val cache: ICache<T>?, private val ne
                         // to remove the entity from the local cache with the temporary ID.
                         cache?.delete(id)
                     }
+                    ret?.let { cache?.save(it) }
                 } catch (e: IOException) {
                     syncManager?.enqueueRequest(networkManager?.collectionName,
                     networkManager, if (bRealmGeneratedId == true) SyncRequest.HttpVerb.POST else SyncRequest.HttpVerb.PUT, id)
-                    throw e
+                    //throw e
                 }
-                ret?.let { cache?.save(it) }
             }
             WritePolicy.FORCE_NETWORK -> {
                 Logger.INFO("Start saving entity")

--- a/java-api-core/src/com/kinvey/java/store/requests/data/save/SaveRequest.kt
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/save/SaveRequest.kt
@@ -16,6 +16,7 @@
 
 package com.kinvey.java.store.requests.data.save
 
+import com.google.api.client.http.HttpResponseException
 import com.google.api.client.json.GenericJson
 import com.kinvey.java.Constants
 import com.kinvey.java.Logger
@@ -75,7 +76,7 @@ class SaveRequest<T : GenericJson>(private val cache: ICache<T>?, private val ne
                 } catch (e: IOException) {
                     syncManager?.enqueueRequest(networkManager?.collectionName,
                     networkManager, if (bRealmGeneratedId == true) SyncRequest.HttpVerb.POST else SyncRequest.HttpVerb.PUT, id)
-                    //throw e
+                    if (e is HttpResponseException && e.statusCode == 401) throw IOException(e)
                 }
             }
             WritePolicy.FORCE_NETWORK -> {


### PR DESCRIPTION
#### Description
Fix for `DataStore.save` failing for network error invokes the `onFailure` handler.
#### Changes
* Fix for `DataStore.save` failing for network error invokes the `onFailure` handler, now it returns onSuccess if item was saved in cache if was no connection, for `AUTO` or `SYNC` store types.
* Made some correction in tests: `DataStoreTest#testSaveConnectErrorAuto`, `DataStoreTest#testSaveNoAccess` that checking old `DataStore.save` behavior, that was changed.
* Added new tests to check new `DataStore.save` logic behaviour.
#### Tests
Instrumented.
