### PR TITLE
KDEV 547: Return items count with GET requests

### DIFF
--- a/android-lib/build.gradle
+++ b/android-lib/build.gradle
@@ -168,6 +168,8 @@ dependencies {
   // Multidex Support for testing
   androidTestImplementation group: 'androidx.multidex', name: 'multidex-instrumentation', version: '2.0.0'
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+
+  androidTestImplementation 'androidx.test.ext:junit:1.1.1'
 }
 
 task superJar(type: Jar) {

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/DataStoreCountHeaderTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/DataStoreCountHeaderTest.kt
@@ -2,6 +2,7 @@ package com.kinvey.androidTest.store.data
 
 import androidx.test.filters.SmallTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.kinvey.android.callback.KinveyReadCallback
 import com.kinvey.android.store.DataStore
 import com.kinvey.androidTest.model.Person
 import com.kinvey.androidTest.store.datastore.BaseDataStoreTest
@@ -9,6 +10,7 @@ import com.kinvey.java.store.StoreType
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
 
 @RunWith(AndroidJUnit4::class)
 @SmallTest
@@ -66,6 +68,31 @@ class DataStoreCountHeaderTest : BaseDataStoreTest() {
         testFindWithCount(StoreType.NETWORK)
     }
 
+    @Test
+    @Throws(InterruptedException::class)
+    fun testFindWithCountAuto() {
+        testFindWithCount(StoreType.AUTO)
+    }
+
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testFindWithCountCache() {
+        val store = DataStore.collection(COLLECTION, Person::class.java, StoreType.CACHE, client)
+        try {
+            store.findWithCount(client?.query()!!)
+            Assert.assertFalse(true)
+        } catch (e: IllegalArgumentException) {
+            Assert.assertTrue(e.message?.contains("StoreType.CACHE isn't supported") == true)
+        }
+        try {
+            store.findWithCount(client?.query()!!,  DefaultKinveyReadCallback(CountDownLatch(0)))
+            Assert.assertFalse(true)
+        } catch (e: IllegalArgumentException) {
+            Assert.assertTrue(e.message?.contains("StoreType.CACHE isn't supported") == true)
+        }
+    }
+
     private fun testFindWithCount(storeType: StoreType) {
         val store = DataStore.collection(COLLECTION, Person::class.java, storeType, client)
         Assert.assertFalse(store.isAddCountHeader)
@@ -86,6 +113,34 @@ class DataStoreCountHeaderTest : BaseDataStoreTest() {
         Assert.assertNotNull(findCallback.result)
         Assert.assertEquals(findCallback.result?.result?.size, 2)
         Assert.assertNull(findCallback.result?.count)
+        clearBackend(store)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testFindWithCountAutoDelta() {
+
+        val store = DataStore.collection(COLLECTION, Person::class.java, StoreType.SYNC, client)
+        store.isDeltaSetCachingEnabled = true
+        store.isAddCountHeader = false
+        clearBackend(store)
+        createAndSavePerson(store, TEST_USERNAME)
+        createAndSavePerson(store, TEST_USERNAME_2)
+        createAndSavePerson(store, TEST_USERNAME_3)
+        val query = client?.query()
+        query?.setSkip(1)
+        var findCallback = findWithCount(store, client!!.query(), LONG_TIMEOUT)
+        Assert.assertNotNull(findCallback.result)
+        Assert.assertNotNull(findCallback.result?.count)
+        Assert.assertEquals(2, findCallback.result?.count)
+
+
+        store.isAddCountHeader = true
+        findCallback = findWithCount(store, client!!.query(), LONG_TIMEOUT)
+        Assert.assertNotNull(findCallback.result)
+        Assert.assertNotNull(findCallback.result?.count)
+        Assert.assertEquals(2, findCallback.result?.count)
+
         clearBackend(store)
     }
 

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/DataStoreCountHeaderTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/DataStoreCountHeaderTest.kt
@@ -175,4 +175,58 @@ class DataStoreCountHeaderTest : BaseDataStoreTest() {
         clearBackend(store)
     }
 
+    @Test
+    @Throws(InterruptedException::class)
+    fun testQueryNetwork() {
+        testQuery(StoreType.NETWORK)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testQuerySync() {
+        testQuery(StoreType.SYNC)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testQueryAuto() {
+        testQuery(StoreType.AUTO)
+    }
+
+    private fun testQuery(storeType: StoreType) {
+        val store = DataStore.collection(COLLECTION, Person::class.java, storeType, client)
+        clearBackend(store)
+        createAndSavePerson(store, TEST_USERNAME)
+        createAndSavePerson(store, TEST_USERNAME)
+        createAndSavePerson(store, TEST_USERNAME)
+
+        var query = client?.query()
+        query?.equals("username", TEST_USERNAME)
+        var findCallback = findWithCount(store, query!!, LONG_TIMEOUT)
+        Assert.assertNotNull(findCallback.result)
+        Assert.assertNotNull(findCallback.result?.count)
+        Assert.assertEquals(3, findCallback.result?.count)
+        Assert.assertEquals(3, findCallback.result?.result?.size)
+
+        //check that request ignores `limit` parameter for count
+        query = client?.query()
+        query?.equals("username", TEST_USERNAME)?.setLimit(1)
+        findCallback = findWithCount(store, query!!, LONG_TIMEOUT)
+        Assert.assertNotNull(findCallback.result)
+        Assert.assertNotNull(findCallback.result?.count)
+        Assert.assertEquals(3, findCallback.result?.count)
+        Assert.assertEquals(1, findCallback.result?.result?.size)
+
+        //check that request ignores `skip` parameter for count
+        query = client?.query()
+        query?.equals("username", TEST_USERNAME)?.setSkip(1)
+        findCallback = findWithCount(store, query!!, LONG_TIMEOUT)
+        Assert.assertNotNull(findCallback.result)
+        Assert.assertNotNull(findCallback.result?.count)
+        Assert.assertEquals(3, findCallback.result?.count)
+        Assert.assertEquals(2, findCallback.result?.result?.size)
+
+        clearBackend(store)
+    }
+
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/DataStoreCountHeaderTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/DataStoreCountHeaderTest.kt
@@ -26,24 +26,31 @@ class DataStoreCountHeaderTest : BaseDataStoreTest() {
         testFindByQueryWithCount(StoreType.AUTO)
     }
 
+    @Test
+    @Throws(InterruptedException::class)
+    fun testFindByQueryWithCountSync() {
+        testFindByQueryWithCount(StoreType.SYNC)
+    }
+
     private fun testFindByQueryWithCount(storeType: StoreType) {
-        val storeNetwork = DataStore.collection(COLLECTION, Person::class.java, storeType, client)
-        clearBackend(storeNetwork)
-        createAndSavePerson(storeNetwork, TEST_USERNAME)
-        createAndSavePerson(storeNetwork, TEST_USERNAME_2)
-        var findCallback = find(storeNetwork, LONG_TIMEOUT)
+        val store = DataStore.collection(COLLECTION, Person::class.java, storeType, client)
+        Assert.assertFalse(store.isAddCountHeader)
+        clearBackend(store)
+        createAndSavePerson(store, TEST_USERNAME)
+        createAndSavePerson(store, TEST_USERNAME_2)
+        var findCallback = find(store, LONG_TIMEOUT)
         Assert.assertNotNull(findCallback.result)
         Assert.assertNull(findCallback.result?.count)
-        storeNetwork.isAddCountHeader = true
-        findCallback = find(storeNetwork, LONG_TIMEOUT)
+        store.isAddCountHeader = true
+        findCallback = find(store, LONG_TIMEOUT)
         Assert.assertNotNull(findCallback.result)
         Assert.assertNotNull(findCallback.result?.count)
         Assert.assertEquals(findCallback.result?.result?.size, 2)
         Assert.assertEquals(findCallback.result?.count, 2)
-        storeNetwork.isAddCountHeader = false
-        findCallback = find(storeNetwork, LONG_TIMEOUT)
+        store.isAddCountHeader = false
+        findCallback = find(store, LONG_TIMEOUT)
         Assert.assertNull(findCallback.result?.count)
-        clearBackend(storeNetwork)
+        clearBackend(store)
     }
 
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/DataStoreCountHeaderTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/DataStoreCountHeaderTest.kt
@@ -1,0 +1,49 @@
+package com.kinvey.androidTest.store.data
+
+import androidx.test.filters.SmallTest
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.kinvey.android.store.DataStore
+import com.kinvey.androidTest.model.Person
+import com.kinvey.androidTest.store.datastore.BaseDataStoreTest
+import com.kinvey.java.store.StoreType
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+class DataStoreCountHeaderTest : BaseDataStoreTest() {
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testFindByQueryWithCountNetwork() {
+        testFindByQueryWithCount(StoreType.NETWORK)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testFindByQueryWithCountAuto() {
+        testFindByQueryWithCount(StoreType.AUTO)
+    }
+
+    private fun testFindByQueryWithCount(storeType: StoreType) {
+        val storeNetwork = DataStore.collection(COLLECTION, Person::class.java, storeType, client)
+        clearBackend(storeNetwork)
+        createAndSavePerson(storeNetwork, TEST_USERNAME)
+        createAndSavePerson(storeNetwork, TEST_USERNAME_2)
+        var findCallback = find(storeNetwork, LONG_TIMEOUT)
+        Assert.assertNotNull(findCallback.result)
+        Assert.assertNull(findCallback.result?.count)
+        storeNetwork.isAddCountHeader = true
+        findCallback = find(storeNetwork, LONG_TIMEOUT)
+        Assert.assertNotNull(findCallback.result)
+        Assert.assertNotNull(findCallback.result?.count)
+        Assert.assertEquals(findCallback.result?.result?.size, 2)
+        Assert.assertEquals(findCallback.result?.count, 2)
+        storeNetwork.isAddCountHeader = false
+        findCallback = find(storeNetwork, LONG_TIMEOUT)
+        Assert.assertNull(findCallback.result?.count)
+        clearBackend(storeNetwork)
+    }
+
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/DataStoreCountHeaderTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/DataStoreCountHeaderTest.kt
@@ -2,7 +2,6 @@ package com.kinvey.androidTest.store.data
 
 import androidx.test.filters.SmallTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.kinvey.android.callback.KinveyReadCallback
 import com.kinvey.android.store.DataStore
 import com.kinvey.androidTest.model.Person
 import com.kinvey.androidTest.store.datastore.BaseDataStoreTest
@@ -36,20 +35,20 @@ class DataStoreCountHeaderTest : BaseDataStoreTest() {
 
     private fun testFindByQueryWithCount(storeType: StoreType) {
         val store = DataStore.collection(COLLECTION, Person::class.java, storeType, client)
-        Assert.assertFalse(store.isAddCountHeader)
+        Assert.assertFalse(store.hasCountHeader)
         clearBackend(store)
         createAndSavePerson(store, TEST_USERNAME)
         createAndSavePerson(store, TEST_USERNAME_2)
         var findCallback = find(store, LONG_TIMEOUT)
         Assert.assertNotNull(findCallback.result)
         Assert.assertNull(findCallback.result?.count)
-        store.isAddCountHeader = true
+        store.hasCountHeader = true
         findCallback = find(store, LONG_TIMEOUT)
         Assert.assertNotNull(findCallback.result)
         Assert.assertNotNull(findCallback.result?.count)
         Assert.assertEquals(findCallback.result?.result?.size, 2)
         Assert.assertEquals(findCallback.result?.count, 2)
-        store.isAddCountHeader = false
+        store.hasCountHeader = false
         findCallback = find(store, LONG_TIMEOUT)
         Assert.assertNull(findCallback.result?.count)
         clearBackend(store)
@@ -93,7 +92,7 @@ class DataStoreCountHeaderTest : BaseDataStoreTest() {
 
     private fun testFindWithCount(storeType: StoreType) {
         val store = DataStore.collection(COLLECTION, Person::class.java, storeType, client)
-        Assert.assertFalse(store.isAddCountHeader)
+        Assert.assertFalse(store.hasCountHeader)
         clearBackend(store)
         createAndSavePerson(store, TEST_USERNAME)
         createAndSavePerson(store, TEST_USERNAME_2)
@@ -106,7 +105,7 @@ class DataStoreCountHeaderTest : BaseDataStoreTest() {
         Assert.assertEquals(findCallback.result?.result?.size, 2)
         Assert.assertNull(findCallback.result?.count)
 
-        store.isAddCountHeader = false
+        store.hasCountHeader = false
         findCallback = find(store, LONG_TIMEOUT)
         Assert.assertNotNull(findCallback.result)
         Assert.assertEquals(findCallback.result?.result?.size, 2)
@@ -135,7 +134,7 @@ class DataStoreCountHeaderTest : BaseDataStoreTest() {
     private fun testFindWithCountDelta(storeType: StoreType) {
         val store = DataStore.collection(COLLECTION, Person::class.java, storeType, client)
         store.isDeltaSetCachingEnabled = true
-        store.isAddCountHeader = false
+        store.hasCountHeader = false
         clearBackend(store)
         createAndSavePerson(store, TEST_USERNAME)
         createAndSavePerson(store, TEST_USERNAME_2)

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/DataStoreCountHeaderTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/DataStoreCountHeaderTest.kt
@@ -53,4 +53,40 @@ class DataStoreCountHeaderTest : BaseDataStoreTest() {
         clearBackend(store)
     }
 
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testFindWithCountSync() {
+        testFindWithCount(StoreType.SYNC)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testFindWithCountNetwork() {
+        testFindWithCount(StoreType.NETWORK)
+    }
+
+    private fun testFindWithCount(storeType: StoreType) {
+        val store = DataStore.collection(COLLECTION, Person::class.java, storeType, client)
+        Assert.assertFalse(store.isAddCountHeader)
+        clearBackend(store)
+        createAndSavePerson(store, TEST_USERNAME)
+        createAndSavePerson(store, TEST_USERNAME_2)
+        var findCallback = findWithCount(store, client!!.query(), LONG_TIMEOUT)
+        Assert.assertNotNull(findCallback.result)
+        Assert.assertEquals(findCallback.result?.count, 2)
+
+        findCallback = find(store, LONG_TIMEOUT)
+        Assert.assertNotNull(findCallback.result)
+        Assert.assertEquals(findCallback.result?.result?.size, 2)
+        Assert.assertNull(findCallback.result?.count)
+
+        store.isAddCountHeader = false
+        findCallback = find(store, LONG_TIMEOUT)
+        Assert.assertNotNull(findCallback.result)
+        Assert.assertEquals(findCallback.result?.result?.size, 2)
+        Assert.assertNull(findCallback.result?.count)
+        clearBackend(store)
+    }
+
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/BaseDataStoreTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/BaseDataStoreTest.kt
@@ -519,6 +519,17 @@ open class BaseDataStoreTest {
     }
 
     @Throws(InterruptedException::class)
+    fun findWithCount(store: DataStore<Person>, query: Query, seconds: Int): DefaultKinveyReadCallback {
+        val latch = CountDownLatch(1)
+        val callback = DefaultKinveyReadCallback(latch)
+        val looperThread = LooperThread(Runnable { store.findWithCount(query, callback) })
+        looperThread.start()
+        latch.await()
+        looperThread.mHandler?.sendMessage(Message())
+        return callback
+    }
+
+    @Throws(InterruptedException::class)
     fun testFindByQuery(storeType: StoreType) {
         val store = collection(COLLECTION, Person::class.java, storeType, client)
         clearBackend(store)

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/BaseDataStoreTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/BaseDataStoreTest.kt
@@ -968,6 +968,7 @@ open class BaseDataStoreTest {
         const val COLLECTION = "PersonsNew"
         const val TEST_USERNAME = "Test_UserName"
         const val TEST_USERNAME_2 = "Test_UserName_2"
+        const val TEST_USERNAME_3 = "Test_UserName_3"
         const val TEST_TEMP_USERNAME = "Temp_UserName"
         const val USERNAME = "username"
         const val ID = "_id"

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreTest.kt
@@ -4139,49 +4139,5 @@ class DataStoreTest() : BaseDataStoreTest() {
         assertNotNull(store.query())
     }
 
-    @Test
-    @Throws(InterruptedException::class)
-    fun testFindByQueryWithCountNetwork() {
-        client?.enableDebugLogging()
-        val storeNetwork = collection(COLLECTION, Person::class.java, StoreType.NETWORK, client)
-        storeNetwork.isAddCountHeader = true
-        clearBackend(storeNetwork)
-        createAndSavePerson(storeNetwork, TEST_USERNAME)
-        createAndSavePerson(storeNetwork, TEST_USERNAME_2)
-        var findCallback = find(storeNetwork, LONG_TIMEOUT)
-        assertNotNull(findCallback.result)
-        assertNotNull(findCallback.result?.count)
-        assertEquals(findCallback.result?.result?.size, 2)
-        assertEquals(findCallback.result?.count, 2)
-
-        storeNetwork.isAddCountHeader = false
-        findCallback = find(storeNetwork, LONG_TIMEOUT)
-        assertNull(findCallback.result?.count)
-
-        clearBackend(storeNetwork)
-    }
-
-
-/*    @Test
-    @Throws(InterruptedException::class)
-    fun testFindByQueryWithCountLocal() {
-        client?.enableDebugLogging()
-        val storeNetwork = collection(COLLECTION, Person::class.java, StoreType.SYNC, client)
-        storeNetwork.isAddCountHeader = true
-        clearBackend(storeNetwork)
-        createAndSavePerson(storeNetwork, TEST_USERNAME)
-        createAndSavePerson(storeNetwork, TEST_USERNAME_2)
-        var findCallback = find(storeNetwork, LONG_TIMEOUT)
-        assertNotNull(findCallback.result)
-        assertNotNull(findCallback.result?.count)
-        assertEquals(findCallback.result?.result?.size, 2)
-        assertEquals(findCallback.result?.count, 2)
-
-        storeNetwork.isAddCountHeader = false
-        findCallback = find(storeNetwork, LONG_TIMEOUT)
-        assertNull(findCallback.result?.count)
-
-        clearBackend(storeNetwork)
-    }*/
 
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreTest.kt
@@ -4138,4 +4138,50 @@ class DataStoreTest() : BaseDataStoreTest() {
         val store = collection(COLLECTION, Person::class.java, StoreType.SYNC, client)
         assertNotNull(store.query())
     }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testFindByQueryWithCountNetwork() {
+        client?.enableDebugLogging()
+        val storeNetwork = collection(COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        storeNetwork.isAddCountHeader = true
+        clearBackend(storeNetwork)
+        createAndSavePerson(storeNetwork, TEST_USERNAME)
+        createAndSavePerson(storeNetwork, TEST_USERNAME_2)
+        var findCallback = find(storeNetwork, LONG_TIMEOUT)
+        assertNotNull(findCallback.result)
+        assertNotNull(findCallback.result?.count)
+        assertEquals(findCallback.result?.result?.size, 2)
+        assertEquals(findCallback.result?.count, 2)
+
+        storeNetwork.isAddCountHeader = false
+        findCallback = find(storeNetwork, LONG_TIMEOUT)
+        assertNull(findCallback.result?.count)
+
+        clearBackend(storeNetwork)
+    }
+
+
+/*    @Test
+    @Throws(InterruptedException::class)
+    fun testFindByQueryWithCountLocal() {
+        client?.enableDebugLogging()
+        val storeNetwork = collection(COLLECTION, Person::class.java, StoreType.SYNC, client)
+        storeNetwork.isAddCountHeader = true
+        clearBackend(storeNetwork)
+        createAndSavePerson(storeNetwork, TEST_USERNAME)
+        createAndSavePerson(storeNetwork, TEST_USERNAME_2)
+        var findCallback = find(storeNetwork, LONG_TIMEOUT)
+        assertNotNull(findCallback.result)
+        assertNotNull(findCallback.result?.count)
+        assertEquals(findCallback.result?.result?.size, 2)
+        assertEquals(findCallback.result?.count, 2)
+
+        storeNetwork.isAddCountHeader = false
+        findCallback = find(storeNetwork, LONG_TIMEOUT)
+        assertNull(findCallback.result?.count)
+
+        clearBackend(storeNetwork)
+    }*/
+
 }

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.kt
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.kt
@@ -49,6 +49,8 @@ class RealmCache<T : GenericJson>(val collection: String, private val mCacheMana
             field = if (value > 0) value else 0
         }
 
+    override var isAddCount: Boolean? = false
+
     /**
      * Get items from the realm with sorting it it exists
      * @param realmQuery

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
@@ -308,6 +308,20 @@ open class DataStore<T : GenericJson> : BaseDataStore<T> {
                 getWrappedCacheCallback(cachedCallback)).execute()
     }
 
+    /**
+     * Asynchronous request to fetch an list of Entities using a Query object with getting count of all items in collection.
+     *
+     *
+     * Constructs an asynchronous request to fetch an List of Entities, filtering by a Query object
+     * with getting count of all items in collection.  Uses KinveyReadCallback<T> to return an List of type T,
+     * count of all items which contains in collection for the query.
+     * Queries can be constructed with [Query].
+     * An empty Query object will return all items in the collection.
+    </T> *
+     *
+     * @param query [Query] to filter the results.
+     * @param callback either successfully returns list of resolved entities, count of all items or an error
+     */
     fun findWithCount(query: Query, callback: KinveyReadCallback<T>) {
         Preconditions.checkNotNull(client, "client must not be null")
         Preconditions.checkArgument(client?.isInitialize ?: false, "client must be initialized.")

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
@@ -312,6 +312,7 @@ open class DataStore<T : GenericJson> : BaseDataStore<T> {
         Preconditions.checkNotNull(client, "client must not be null")
         Preconditions.checkArgument(client?.isInitialize ?: false, "client must be initialized.")
         Preconditions.checkNotNull(query, "Query must not be null.")
+        Preconditions.checkArgument(storeType != StoreType.CACHE, "StoreType.CACHE isn't supported")
         AsyncRequest(this, methodMap!![KEY_GET_BY_QUERY_WITH_COUNT], callback, query).execute()
     }
 

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
@@ -162,6 +162,7 @@ open class DataStore<T : GenericJson> : BaseDataStore<T> {
         try {
             tempMap[KEY_GET_BY_ID] = BaseDataStore::class.java.getMethod(BaseDataStore.FIND, String::class.java, KinveyCachedClientCallback::class.java)
             tempMap[KEY_GET_BY_QUERY] = BaseDataStore::class.java.getMethod(BaseDataStore.FIND, Query::class.java, KinveyCachedClientCallback::class.java)
+            tempMap[KEY_GET_BY_QUERY_WITH_COUNT] = BaseDataStore::class.java.getMethod(BaseDataStore.FIND_WITH_COUNT, Query::class.java)
             tempMap[KEY_GET_ALL] = BaseDataStore::class.java.getMethod(BaseDataStore.FIND, KinveyCachedClientCallback::class.java)
             tempMap[KEY_GET_BY_IDS] = BaseDataStore::class.java.getMethod(BaseDataStore.FIND, Iterable::class.java, KinveyCachedClientCallback::class.java)
 
@@ -305,6 +306,13 @@ open class DataStore<T : GenericJson> : BaseDataStore<T> {
         Preconditions.checkNotNull(query, "Query must not be null.")
         AsyncRequest(this, methodMap!![KEY_GET_BY_QUERY], callback, query,
                 getWrappedCacheCallback(cachedCallback)).execute()
+    }
+
+    fun findWithCount(query: Query, callback: KinveyReadCallback<T>) {
+        Preconditions.checkNotNull(client, "client must not be null")
+        Preconditions.checkArgument(client?.isInitialize ?: false, "client must be initialized.")
+        Preconditions.checkNotNull(query, "Query must not be null.")
+        AsyncRequest(this, methodMap!![KEY_GET_BY_QUERY_WITH_COUNT], callback, query).execute()
     }
 
     /**
@@ -1130,6 +1138,7 @@ open class DataStore<T : GenericJson> : BaseDataStore<T> {
         //This makes it very easy to add new wrappers, and allows for a single implementation of an async client request.
         private const val KEY_GET_BY_ID = "KEY_GET_BY_ID"
         private const val KEY_GET_BY_QUERY = "KEY_GET_BY_QUERY"
+        private const val KEY_GET_BY_QUERY_WITH_COUNT = "KEY_GET_BY_QUERY_WITH_COUNT"
         private const val KEY_GET_ALL = "KEY_GET_ALL"
         private const val KEY_GET_BY_IDS = "KEY_GET_BY_IDS"
 

--- a/java-api-core/src/com/kinvey/java/Constants.kt
+++ b/java-api-core/src/com/kinvey/java/Constants.kt
@@ -45,4 +45,8 @@ object Constants {
     const val HOSTNAME_API = "baas.kinvey.com"
     const val HOSTNAME_AUTH = "auth.kinvey.com"
 
+    //Count header
+    const val X_KINVEY_INCLUDE_ITEMS_COUNT = "X-Kinvey-Include-Items-Count"
+    const val X_KINVEY_ITEMS_COUNT_CAMEL_CASE = "X-Kinvey-Items-Count"
+    const val X_KINVEY_ITEMS_COUNT = "x-kinvey-items-count"
 }

--- a/java-api-core/src/com/kinvey/java/cache/ICache.kt
+++ b/java-api-core/src/com/kinvey/java/cache/ICache.kt
@@ -35,6 +35,8 @@ interface ICache<T : GenericJson?> {
      */
     val first: T?
 
+    var isAddCount: Boolean?
+
     /**
      * get current ttl value
      * @return current ttl value

--- a/java-api-core/src/com/kinvey/java/core/AbstractKinveyReadRequest.kt
+++ b/java-api-core/src/com/kinvey/java/core/AbstractKinveyReadRequest.kt
@@ -87,6 +87,11 @@ protected constructor(abstractKinveyJsonClient: AbstractClient<*>?, requestMetho
                 } else if (response.headers.containsKey(Constants.X_KINVEY_REQUEST_START_CAMEL_CASE)) {
                     ret.lastRequestTime = response.headers.getHeaderStringValues(Constants.X_KINVEY_REQUEST_START_CAMEL_CASE)[0].toUpperCase(Locale.US)
                 }
+                if (response.headers.containsKey(Constants.X_KINVEY_ITEMS_COUNT)) {
+                    ret.count = response.headers.getHeaderStringValues(Constants.X_KINVEY_ITEMS_COUNT)[0].toInt()
+                } else if (response.headers.containsKey(Constants.X_KINVEY_ITEMS_COUNT_CAMEL_CASE)) {
+                    ret.count = response.headers.getHeaderStringValues(Constants.X_KINVEY_ITEMS_COUNT_CAMEL_CASE)[0].toInt()
+                }
                 ret.result = results
                 ret.listOfExceptions = exceptions
                 return ret

--- a/java-api-core/src/com/kinvey/java/model/KinveyReadResponse.kt
+++ b/java-api-core/src/com/kinvey/java/model/KinveyReadResponse.kt
@@ -6,5 +6,6 @@ package com.kinvey.java.model
 
 data class KinveyReadResponse<T>(
     var lastRequestTime: String? = null,
-    var result: List<T>? = null
+    var result: List<T>? = null,
+    var count: Int? = null
 ) : AbstractKinveyExceptionsListResponse()

--- a/java-api-core/src/com/kinvey/java/network/NetworkManager.kt
+++ b/java-api-core/src/com/kinvey/java/network/NetworkManager.kt
@@ -155,9 +155,9 @@ open class NetworkManager<T : GenericJson>(
      * @throws java.io.IOException
      */
     @Throws(IOException::class)
-    fun getBlocking(query: Query?): Get<T>? {
+    fun getBlocking(query: Query?, isAddCountHeader: Boolean = false): Get<T>? {
         Preconditions.checkNotNull(query)
-        val get = Get(this, client, query, currentClass)
+        val get = Get(this, client, query, currentClass, isAddCountHeader)
         client?.initializeRequest(get)
         return get
     }
@@ -703,19 +703,22 @@ open class NetworkManager<T : GenericJson>(
         @Key("retainReferences")
         var retainReferences: String? = null
 
+        var isAddCountHeader  = false
+
         private fun addHeaders(networkManager: NetworkManager<T>) {
             getRequestHeaders()["X-Kinvey-Client-App-Version"] = networkManager.clientAppVersion
             if (!networkManager.customRequestProperties.isNullOrEmpty()) {
                 getRequestHeaders()["X-Kinvey-Custom-Request-Properties"] = Gson().toJson(networkManager.customRequestProperties)
             }
-            if (networkManager.isAddCountHeader) {
+            if (networkManager.isAddCountHeader || isAddCountHeader) {
                 getRequestHeaders()[Constants.X_KINVEY_INCLUDE_ITEMS_COUNT] = "true"
             }
         }
 
-        constructor(networkManager: NetworkManager<T>, client: AbstractClient<*>?, query: Query?, myClass: Class<T>?)
+        constructor(networkManager: NetworkManager<T>, client: AbstractClient<*>?, query: Query?, myClass: Class<T>?,  isAddCountHeader: Boolean = false)
             : super(client, HttpVerb.GET.verb, GET_REST_PATH, null, myClass) {
             this.collectionName = networkManager.collectionName
+            this.isAddCountHeader = isAddCountHeader
             queryFilter = query?.getQueryFilterJson(client?.jsonFactory)
             val queryLimit = query?.limit ?: 0
             val querySkip = query?.skip ?: 0
@@ -727,9 +730,10 @@ open class NetworkManager<T : GenericJson>(
         }
 
         constructor(networkManager: NetworkManager<T>, client: AbstractClient<*>?, query: Query?, myClass: Class<T>?,
-                    resolves: Array<String>?, resolveDepth: Int, retain: Boolean)
+                    resolves: Array<String>?, resolveDepth: Int, retain: Boolean, isAddCountHeader: Boolean = false)
             : super(client, HttpVerb.GET.verb, GET_REST_PATH, null, myClass) {
             this.collectionName = networkManager.collectionName
+            this.isAddCountHeader = isAddCountHeader
             queryFilter = query?.getQueryFilterJson(client?.jsonFactory)
             val queryLimit = query?.limit ?: 0
             val querySkip = query?.skip ?: 0
@@ -743,9 +747,10 @@ open class NetworkManager<T : GenericJson>(
             addHeaders(networkManager)
         }
 
-        constructor(networkManager: NetworkManager<T>, client: AbstractClient<*>?, queryString: String?, myClass: Class<T>?)
+        constructor(networkManager: NetworkManager<T>, client: AbstractClient<*>?, queryString: String?, myClass: Class<T>?,  isAddCountHeader: Boolean = false)
             : super(client, HttpVerb.GET.verb, GET_REST_PATH, null, myClass) {
             this.collectionName = networkManager.collectionName
+            this.isAddCountHeader = isAddCountHeader
             queryFilter = if (queryString != "{}") queryString else null
             setTemplateExpand(false)
             addHeaders(networkManager)

--- a/java-api-core/src/com/kinvey/java/network/NetworkManager.kt
+++ b/java-api-core/src/com/kinvey/java/network/NetworkManager.kt
@@ -33,12 +33,10 @@ import com.kinvey.java.cache.ICache
 import com.kinvey.java.core.*
 import com.kinvey.java.deltaset.DeltaSetItem
 import com.kinvey.java.deltaset.DeltaSetMerge
-import com.kinvey.java.dto.BaseUser
 import com.kinvey.java.dto.BatchList
 import com.kinvey.java.dto.DeviceId
 import com.kinvey.java.model.*
 import com.kinvey.java.query.MongoQueryFilter.MongoQueryFilterBuilder
-import com.sun.security.ntlm.Client
 import java.io.IOException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
@@ -81,7 +79,7 @@ open class NetworkManager<T : GenericJson>(
         }
 
     var clientAppVersion: String? = null
-    var isAddCountHeader: Boolean = false
+    var hasCountHeader: Boolean = false
     var customRequestProperties: GenericData? = GenericData()
         private set
 
@@ -155,9 +153,9 @@ open class NetworkManager<T : GenericJson>(
      * @throws java.io.IOException
      */
     @Throws(IOException::class)
-    fun getBlocking(query: Query?, isAddCountHeader: Boolean = false): Get<T>? {
+    fun getBlocking(query: Query?, hasCountHeader: Boolean = false): Get<T>? {
         Preconditions.checkNotNull(query)
-        val get = Get(this, client, query, currentClass, isAddCountHeader)
+        val get = Get(this, client, query, currentClass, hasCountHeader)
         client?.initializeRequest(get)
         return get
     }
@@ -703,22 +701,22 @@ open class NetworkManager<T : GenericJson>(
         @Key("retainReferences")
         var retainReferences: String? = null
 
-        var isAddCountHeader  = false
+        var hasCountHeader  = false
 
         private fun addHeaders(networkManager: NetworkManager<T>) {
             getRequestHeaders()["X-Kinvey-Client-App-Version"] = networkManager.clientAppVersion
             if (!networkManager.customRequestProperties.isNullOrEmpty()) {
                 getRequestHeaders()["X-Kinvey-Custom-Request-Properties"] = Gson().toJson(networkManager.customRequestProperties)
             }
-            if (networkManager.isAddCountHeader || isAddCountHeader) {
+            if (networkManager.hasCountHeader || hasCountHeader) {
                 getRequestHeaders()[Constants.X_KINVEY_INCLUDE_ITEMS_COUNT] = "true"
             }
         }
 
-        constructor(networkManager: NetworkManager<T>, client: AbstractClient<*>?, query: Query?, myClass: Class<T>?,  isAddCountHeader: Boolean = false)
+        constructor(networkManager: NetworkManager<T>, client: AbstractClient<*>?, query: Query?, myClass: Class<T>?,  hasCountHeader: Boolean = false)
             : super(client, HttpVerb.GET.verb, GET_REST_PATH, null, myClass) {
             this.collectionName = networkManager.collectionName
-            this.isAddCountHeader = isAddCountHeader
+            this.hasCountHeader = hasCountHeader
             queryFilter = query?.getQueryFilterJson(client?.jsonFactory)
             val queryLimit = query?.limit ?: 0
             val querySkip = query?.skip ?: 0
@@ -730,10 +728,10 @@ open class NetworkManager<T : GenericJson>(
         }
 
         constructor(networkManager: NetworkManager<T>, client: AbstractClient<*>?, query: Query?, myClass: Class<T>?,
-                    resolves: Array<String>?, resolveDepth: Int, retain: Boolean, isAddCountHeader: Boolean = false)
+                    resolves: Array<String>?, resolveDepth: Int, retain: Boolean, hasCountHeader: Boolean = false)
             : super(client, HttpVerb.GET.verb, GET_REST_PATH, null, myClass) {
             this.collectionName = networkManager.collectionName
-            this.isAddCountHeader = isAddCountHeader
+            this.hasCountHeader = hasCountHeader
             queryFilter = query?.getQueryFilterJson(client?.jsonFactory)
             val queryLimit = query?.limit ?: 0
             val querySkip = query?.skip ?: 0
@@ -747,10 +745,10 @@ open class NetworkManager<T : GenericJson>(
             addHeaders(networkManager)
         }
 
-        constructor(networkManager: NetworkManager<T>, client: AbstractClient<*>?, queryString: String?, myClass: Class<T>?,  isAddCountHeader: Boolean = false)
+        constructor(networkManager: NetworkManager<T>, client: AbstractClient<*>?, queryString: String?, myClass: Class<T>?,  hasCountHeader: Boolean = false)
             : super(client, HttpVerb.GET.verb, GET_REST_PATH, null, myClass) {
             this.collectionName = networkManager.collectionName
-            this.isAddCountHeader = isAddCountHeader
+            this.hasCountHeader = hasCountHeader
             queryFilter = if (queryString != "{}") queryString else null
             setTemplateExpand(false)
             addHeaders(networkManager)

--- a/java-api-core/src/com/kinvey/java/network/NetworkManager.kt
+++ b/java-api-core/src/com/kinvey/java/network/NetworkManager.kt
@@ -81,6 +81,7 @@ open class NetworkManager<T : GenericJson>(
         }
 
     var clientAppVersion: String? = null
+    var isAddCountHeader: Boolean = false
     var customRequestProperties: GenericData? = GenericData()
         private set
 
@@ -702,6 +703,16 @@ open class NetworkManager<T : GenericJson>(
         @Key("retainReferences")
         var retainReferences: String? = null
 
+        private fun addHeaders(networkManager: NetworkManager<T>) {
+            getRequestHeaders()["X-Kinvey-Client-App-Version"] = networkManager.clientAppVersion
+            if (!networkManager.customRequestProperties.isNullOrEmpty()) {
+                getRequestHeaders()["X-Kinvey-Custom-Request-Properties"] = Gson().toJson(networkManager.customRequestProperties)
+            }
+            if (networkManager.isAddCountHeader) {
+                getRequestHeaders()[Constants.X_KINVEY_INCLUDE_ITEMS_COUNT] = "true"
+            }
+        }
+
         constructor(networkManager: NetworkManager<T>, client: AbstractClient<*>?, query: Query?, myClass: Class<T>?)
             : super(client, HttpVerb.GET.verb, GET_REST_PATH, null, myClass) {
             this.collectionName = networkManager.collectionName
@@ -712,10 +723,7 @@ open class NetworkManager<T : GenericJson>(
             skip = if (querySkip > 0) querySkip.toString() else null
             val sortString = query?.sortString
             sortFilter = if (sortString != "") sortString else null
-            getRequestHeaders()["X-Kinvey-Client-App-Version"] = networkManager.clientAppVersion
-            if (!networkManager.customRequestProperties.isNullOrEmpty()) {
-                getRequestHeaders()["X-Kinvey-Custom-Request-Properties"] = Gson().toJson(networkManager.customRequestProperties)
-            }
+            addHeaders(networkManager)
         }
 
         constructor(networkManager: NetworkManager<T>, client: AbstractClient<*>?, query: Query?, myClass: Class<T>?,
@@ -732,10 +740,7 @@ open class NetworkManager<T : GenericJson>(
             this.resolve = Joiner.on(",").join(resolves)
             this.resolveDepth = if (resolveDepth > 0) resolveDepth.toString() else null
             retainReferences = retain.toString()
-            getRequestHeaders()["X-Kinvey-Client-App-Version"] = client?.clientAppVersion
-            if (!networkManager.customRequestProperties.isNullOrEmpty()) {
-                getRequestHeaders()["X-Kinvey-Custom-Request-Properties"] = Gson().toJson(networkManager.customRequestProperties)
-            }
+            addHeaders(networkManager)
         }
 
         constructor(networkManager: NetworkManager<T>, client: AbstractClient<*>?, queryString: String?, myClass: Class<T>?)
@@ -743,10 +748,7 @@ open class NetworkManager<T : GenericJson>(
             this.collectionName = networkManager.collectionName
             queryFilter = if (queryString != "{}") queryString else null
             setTemplateExpand(false)
-            getRequestHeaders()["X-Kinvey-Client-App-Version"] = networkManager.clientAppVersion
-            if (!networkManager.customRequestProperties.isNullOrEmpty()) {
-                getRequestHeaders()["X-Kinvey-Custom-Request-Properties"] = Gson().toJson(networkManager.customRequestProperties)
-            }
+            addHeaders(networkManager)
         }
 
         @Throws(IOException::class)

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.kt
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.kt
@@ -198,6 +198,7 @@ open class BaseDataStore<T : GenericJson> @JvmOverloads protected constructor(
         Preconditions.checkNotNull(client, "client must not be null.")
         Preconditions.checkArgument(client?.isInitialize ?: false, "client must be initialized.")
         Preconditions.checkNotNull(query, "query must not be null.")
+        Preconditions.checkArgument(storeType != StoreType.CACHE, "StoreType.CACHE isn't supported")
         return if (storeType == StoreType.AUTO && isDeltaSetCachingEnabled && !isQueryContainSkipLimit(query)) {
             findBlockingDeltaSync(query)
         } else {

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.kt
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.kt
@@ -645,6 +645,9 @@ open class BaseDataStore<T : GenericJson> @JvmOverloads protected constructor(
             }
             if (query != null && cache != null) {
                 response.result = cache!![query]
+                if (cache?.isAddCount == true) {
+                    response.count = cache?.count(query)?.toInt()
+                }
             }
             response.listOfExceptions = queryCacheResponse?.listOfExceptions ?: ArrayList()
             response.lastRequestTime = queryCacheResponse?.lastRequestTime

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.kt
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.kt
@@ -194,6 +194,17 @@ open class BaseDataStore<T : GenericJson> @JvmOverloads protected constructor(
         }
     }
 
+    fun findWithCount(query: Query): KinveyReadResponse<T>? {
+        Preconditions.checkNotNull(client, "client must not be null.")
+        Preconditions.checkArgument(client?.isInitialize ?: false, "client must be initialized.")
+        Preconditions.checkNotNull(query, "query must not be null.")
+        return if (storeType == StoreType.AUTO && isDeltaSetCachingEnabled && !isQueryContainSkipLimit(query)) {
+            findBlockingDeltaSync(query)
+        } else {
+            ReadQueryRequest(cache, networkManager, this.storeType.readPolicy, query, true).execute()
+        }
+    }
+
     /**
      * Get all objects for given collections
      * @param cachedCallback callback to be executed in case of [StoreType.CACHE] is used to get cached data before network
@@ -875,6 +886,8 @@ open class BaseDataStore<T : GenericJson> @JvmOverloads protected constructor(
         private val BATCH_SIZE = 5
 
         const val FIND = "find"
+
+        const val FIND_WITH_COUNT = "findWithCount"
 
         const val DELETE = "delete"
 

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.kt
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.kt
@@ -194,6 +194,11 @@ open class BaseDataStore<T : GenericJson> @JvmOverloads protected constructor(
         }
     }
 
+    /**
+     * Lookup objects in given collection by given query and count of all items in the collection which satisfy the query
+     * @param query prepared query we have to look with
+     * @return list of objects that are found
+     */
     fun findWithCount(query: Query): KinveyReadResponse<T>? {
         Preconditions.checkNotNull(client, "client must not be null.")
         Preconditions.checkArgument(client?.isInitialize ?: false, "client must be initialized.")
@@ -658,7 +663,7 @@ open class BaseDataStore<T : GenericJson> @JvmOverloads protected constructor(
             if (query != null && cache != null) {
                 response.result = cache!![query]
                 if (cache?.isAddCount == true || isAddCountHeader) {
-                    response.count = cache?.count(client?.query())?.toInt()
+                    response.count = cache?.count(query)?.toInt()
                 }
             }
             response.listOfExceptions = queryCacheResponse?.listOfExceptions ?: ArrayList()

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.kt
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.kt
@@ -90,6 +90,12 @@ open class BaseDataStore<T : GenericJson> @JvmOverloads protected constructor(
      * @param deltaSetCachingEnabled boolean representing if we should use delta set caching
      */
     var isDeltaSetCachingEnabled = false
+    var isAddCountHeader = false
+        set(value) {
+            field = value
+            networkManager.isAddCountHeader = value
+            cache?.isAddCount = value
+        }
 
     internal var liveServiceCallback: KinveyDataStoreLiveServiceCallback<T>? = null
 

--- a/java-api-core/src/com/kinvey/java/store/requests/data/ReadRequest.kt
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/ReadRequest.kt
@@ -47,6 +47,9 @@ class ReadRequest<T : GenericJson>(cache: ICache<T>?, query: Query?, private val
             ReadPolicy.FORCE_LOCAL -> {
                 val response = KinveyReadResponse<T>()
                 response.result = cache?.get(query)
+                if (cache?.isAddCount == true) {
+                    response.count = cache?.count(query)?.toInt()
+                }
                 ret = response
             }
             ReadPolicy.FORCE_NETWORK, ReadPolicy.BOTH -> ret = readItem(query)
@@ -64,6 +67,9 @@ class ReadRequest<T : GenericJson>(cache: ICache<T>?, query: Query?, private val
                 if (networkException != null) {
                     val res = KinveyReadResponse<T>()
                     res.result = cache?.get(query)
+                    if (cache?.isAddCount == true) {
+                        res.count = cache?.count(query)?.toInt()
+                    }
                     ret = res
                 }
             }

--- a/java-api-core/src/com/kinvey/java/store/requests/data/ReadRequest.kt
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/ReadRequest.kt
@@ -17,6 +17,7 @@
 package com.kinvey.java.store.requests.data
 
 import com.google.api.client.json.GenericJson
+import com.kinvey.java.AbstractClient
 import com.kinvey.java.Query
 import com.kinvey.java.cache.ICache
 import com.kinvey.java.model.KinveyReadResponse
@@ -48,7 +49,7 @@ class ReadRequest<T : GenericJson>(cache: ICache<T>?, query: Query?, private val
                 val response = KinveyReadResponse<T>()
                 response.result = cache?.get(query)
                 if (cache?.isAddCount == true) {
-                    response.count = cache?.count(query)?.toInt()
+                    response.count = cache?.count(AbstractClient.sharedInstance?.query())?.toInt()
                 }
                 ret = response
             }
@@ -68,7 +69,7 @@ class ReadRequest<T : GenericJson>(cache: ICache<T>?, query: Query?, private val
                     val res = KinveyReadResponse<T>()
                     res.result = cache?.get(query)
                     if (cache?.isAddCount == true) {
-                        res.count = cache?.count(query)?.toInt()
+                        res.count = cache?.count(AbstractClient.sharedInstance?.query())?.toInt()
                     }
                     ret = res
                 }

--- a/java-api-core/src/com/kinvey/java/store/requests/data/ReadRequest.kt
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/ReadRequest.kt
@@ -49,7 +49,7 @@ class ReadRequest<T : GenericJson>(cache: ICache<T>?, query: Query?, private val
                 val response = KinveyReadResponse<T>()
                 response.result = cache?.get(query)
                 if (cache?.isAddCount == true) {
-                    response.count = cache?.count(AbstractClient.sharedInstance?.query())?.toInt()
+                    response.count = cache?.count(query)?.toInt()
                 }
                 ret = response
             }
@@ -69,7 +69,7 @@ class ReadRequest<T : GenericJson>(cache: ICache<T>?, query: Query?, private val
                     val res = KinveyReadResponse<T>()
                     res.result = cache?.get(query)
                     if (cache?.isAddCount == true) {
-                        res.count = cache?.count(AbstractClient.sharedInstance?.query())?.toInt()
+                        res.count = cache?.count(query)?.toInt()
                     }
                     ret = res
                 }

--- a/java-api-core/src/com/kinvey/java/store/requests/data/read/ReadAllRequest.kt
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/read/ReadAllRequest.kt
@@ -35,6 +35,9 @@ class ReadAllRequest<T : GenericJson>(cache: ICache<T>?, readPolicy: ReadPolicy?
         get() {
             val response = KinveyReadResponse<T>()
             response.result = cache?.get()
+            if (cache?.isAddCount == true) {
+                response.count = response.result?.size
+            }
             return response
         }
 

--- a/java-api-core/src/com/kinvey/java/store/requests/data/read/ReadIdsRequest.kt
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/read/ReadIdsRequest.kt
@@ -38,6 +38,9 @@ class ReadIdsRequest<T : GenericJson>(cache: ICache<T>?, networkManager: Network
         get() {
             val response = KinveyReadResponse<T>()
             response.result = cache?.get(ids)
+            if (cache?.isAddCount == true) {
+                response.count = response.result?.size
+            }
             return response
         }
 

--- a/java-api-core/src/com/kinvey/java/store/requests/data/read/ReadQueryRequest.kt
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/read/ReadQueryRequest.kt
@@ -17,7 +17,6 @@
 package com.kinvey.java.store.requests.data.read
 
 import com.google.api.client.json.GenericJson
-import com.kinvey.java.AbstractClient
 import com.kinvey.java.Query
 import com.kinvey.java.cache.ICache
 import com.kinvey.java.model.KinveyReadResponse
@@ -30,13 +29,13 @@ import java.io.IOException
  * Created by Prots on 2/15/16.
  */
 class ReadQueryRequest<T : GenericJson>(cache: ICache<T>?, networkManager: NetworkManager<T>?, readPolicy: ReadPolicy?,
-                                        private val query: Query, private val isAddCountHeader: Boolean = false) : AbstractReadRequest<T>(cache, readPolicy, networkManager) {
+                                        private val query: Query, private val hasCountHeader: Boolean = false) : AbstractReadRequest<T>(cache, readPolicy, networkManager) {
 
     override val cached: KinveyReadResponse<T>?
         get() {
             val response = KinveyReadResponse<T>()
             response.result = cache?.get(query)
-            if (cache?.isAddCount == true || isAddCountHeader) {
+            if (cache?.isAddCount == true || hasCountHeader) {
                 response.count = cache?.count(query)?.toInt()
             }
             return response
@@ -45,6 +44,6 @@ class ReadQueryRequest<T : GenericJson>(cache: ICache<T>?, networkManager: Netwo
     override val network: KinveyReadResponse<T>?
         @Throws(IOException::class)
         get() {
-            return networkData?.getBlocking(query, isAddCountHeader)?.execute()
+            return networkData?.getBlocking(query, hasCountHeader)?.execute()
         }
 }

--- a/java-api-core/src/com/kinvey/java/store/requests/data/read/ReadQueryRequest.kt
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/read/ReadQueryRequest.kt
@@ -29,13 +29,13 @@ import java.io.IOException
  * Created by Prots on 2/15/16.
  */
 class ReadQueryRequest<T : GenericJson>(cache: ICache<T>?, networkManager: NetworkManager<T>?, readPolicy: ReadPolicy?,
-                                        private val query: Query) : AbstractReadRequest<T>(cache, readPolicy, networkManager) {
+                                        private val query: Query, private val isAddCountHeader: Boolean = false) : AbstractReadRequest<T>(cache, readPolicy, networkManager) {
 
     override val cached: KinveyReadResponse<T>?
         get() {
             val response = KinveyReadResponse<T>()
             response.result = cache?.get(query)
-            if (cache?.isAddCount == true) {
+            if (cache?.isAddCount == true || isAddCountHeader) {
                 response.count = cache?.count(query)?.toInt()
             }
             return response
@@ -44,6 +44,6 @@ class ReadQueryRequest<T : GenericJson>(cache: ICache<T>?, networkManager: Netwo
     override val network: KinveyReadResponse<T>?
         @Throws(IOException::class)
         get() {
-            return networkData?.getBlocking(query)?.execute()
+            return networkData?.getBlocking(query, isAddCountHeader)?.execute()
         }
 }

--- a/java-api-core/src/com/kinvey/java/store/requests/data/read/ReadQueryRequest.kt
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/read/ReadQueryRequest.kt
@@ -35,6 +35,9 @@ class ReadQueryRequest<T : GenericJson>(cache: ICache<T>?, networkManager: Netwo
         get() {
             val response = KinveyReadResponse<T>()
             response.result = cache?.get(query)
+            if (cache?.isAddCount == true) {
+                response.count = cache?.count(query)?.toInt()
+            }
             return response
         }
 

--- a/java-api-core/src/com/kinvey/java/store/requests/data/read/ReadQueryRequest.kt
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/read/ReadQueryRequest.kt
@@ -17,6 +17,7 @@
 package com.kinvey.java.store.requests.data.read
 
 import com.google.api.client.json.GenericJson
+import com.kinvey.java.AbstractClient
 import com.kinvey.java.Query
 import com.kinvey.java.cache.ICache
 import com.kinvey.java.model.KinveyReadResponse
@@ -36,7 +37,7 @@ class ReadQueryRequest<T : GenericJson>(cache: ICache<T>?, networkManager: Netwo
             val response = KinveyReadResponse<T>()
             response.result = cache?.get(query)
             if (cache?.isAddCount == true || isAddCountHeader) {
-                response.count = cache?.count(query)?.toInt()
+                response.count = cache?.count(AbstractClient.sharedInstance?.query())?.toInt()
             }
             return response
         }

--- a/java-api-core/src/com/kinvey/java/store/requests/data/read/ReadQueryRequest.kt
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/read/ReadQueryRequest.kt
@@ -37,7 +37,7 @@ class ReadQueryRequest<T : GenericJson>(cache: ICache<T>?, networkManager: Netwo
             val response = KinveyReadResponse<T>()
             response.result = cache?.get(query)
             if (cache?.isAddCount == true || isAddCountHeader) {
-                response.count = cache?.count(AbstractClient.sharedInstance?.query())?.toInt()
+                response.count = cache?.count(query)?.toInt()
             }
             return response
         }

--- a/java-api-core/test/com/kinvey/java/store/request/read/ReadQueryRequestTest.kt
+++ b/java-api-core/test/com/kinvey/java/store/request/read/ReadQueryRequestTest.kt
@@ -11,6 +11,7 @@ import com.kinvey.java.store.request.Person
 import com.kinvey.java.store.requests.data.read.ReadQueryRequest
 import junit.framework.TestCase
 import org.junit.Before
+import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyList
 import org.mockito.Mockito.*
@@ -41,7 +42,14 @@ class ReadQueryRequestTest : TestCase() {
         val query = Query(MongoQueryFilter.MongoQueryFilterBuilder())
         val request = spy(ReadQueryRequest(cache, spyNetworkManager, ReadPolicy.FORCE_NETWORK, query))
         request.execute()
-        verify(spyNetworkManager, times(1))?.getBlocking(any(Query::class.java))?.execute()
+        verify(spyNetworkManager, times(1))?.getBlocking(any(Query::class.java), ArgumentMatchers.eq(false))?.execute()
+    }
+
+    fun testForceNetworkWithCount() {
+        val query = Query(MongoQueryFilter.MongoQueryFilterBuilder())
+        val request = spy(ReadQueryRequest(cache, spyNetworkManager, ReadPolicy.FORCE_NETWORK, query, true))
+        request.execute()
+        verify(spyNetworkManager, times(1))?.getBlocking(any(Query::class.java), ArgumentMatchers.eq(true))?.execute()
     }
 
     fun  testNetworkOtherwiseLocal() {


### PR DESCRIPTION
#### Description
Add an option to send 'X-Kinvey-Include-Items-Count' header and get the returned items in 'X-Kinvey-Items-Count' returned header.

#### Changes
- Added `isAddCountHeader` parameter to `DataStore`. `isAddCountHeader` is false by default. If `isAddCountHeader` is true, all callbacks `KinveyReadCallback` have not null `count` field with count of all items by a query. `limit` and `skip` query parameters are ignored.
- Added `findWithCount(query: Query, callback: KinveyReadCallback<T>)` method to `DataStore`. The method returns count of all items by the query in  `count` field in `KinveyReadCallback`. This method ignores `isAddCountHeader` parameter from `DataStore`.
- Added `count` field to `KinveyReadCallback` which shows count of all items in collection for a query.  If `isAddCountHeader` is false or `findWithCount` isn't used, the `count` field is null.

#### Tests
Instrumented
