### PR TITLE
KDEV-783: Batch create function will not work for API versions bigger than 5

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultiInsertTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultiInsertTest.kt
@@ -12,6 +12,8 @@ import com.kinvey.java.KinveySaveBatchException
 import com.kinvey.java.core.KinveyJsonResponseException
 import com.kinvey.java.store.StoreType
 import com.kinvey.java.sync.dto.SyncRequest
+import com.kinvey.java.AbstractClient.Companion.kinveyApiVersion
+
 
 import org.junit.Ignore
 import org.junit.Test
@@ -173,6 +175,21 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
     fun testCreateListReturnErrorForEmptyListSync() {
         val list = ArrayList<Person>()
         testCreateEmptyList(list, Person::class.java, Person.COLLECTION, StoreType.SYNC)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun <T : GenericJson> testCreateApiV6() {
+        val personList = createPersonsList(false)
+        kinveyApiVersion = "6"
+        val personStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        clearBackend(personStore)
+        client.syncManager.clear(Person.COLLECTION)
+        val saveCallback = createList(personStore, personList)
+        assertNull(saveCallback.error)
+        assertNotNull(saveCallback.result)
+        clearBackend(personStore)
+        kinveyApiVersion = "5"
     }
 
     // SAVE METHOD TESTS

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
@@ -423,7 +423,7 @@ open class DataStore<T : GenericJson> : BaseDataStore<T> {
         Preconditions.checkArgument(client?.isInitialize ?: false, "client must be initialized.")
         Preconditions.checkNotNull(entities, "Entity cannot be null.")
         Preconditions.checkState(entities.size > 0, "Entity list cannot be empty.")
-        Preconditions.checkState(kinveyApiVersion == KINVEY_API_VERSION_5, "Kinvey api version cannot be less than 5.")
+        Preconditions.checkState(kinveyApiVersion >= KINVEY_API_VERSION_5, "Kinvey api version cannot be less than 5.")
         Logger.INFO("Calling DataStore#createBatch(listObjects)")
         CreateListBatchRequest(this, entities, callback).execute()
     }


### PR DESCRIPTION
#### Description
The `create` function will not work for future API versions bigger than 5.

#### Changes
Update checking API version.

#### Tests
Instrumented.
