### PR TITLE
KDEV-779: The error message from the server is not returned, when some of the items fail

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/BaseDataStoreMultiInsertTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/BaseDataStoreMultiInsertTest.kt
@@ -581,7 +581,7 @@ open class BaseDataStoreMultiInsertTest {
             result = result and (idx == err?.index)
             if (checkErrMsg) {
                 val msg = errMessages?.get(curIdx) ?: ""
-                result = result and (err?.errorMessage?.contains(msg) == true)
+                result = result and (err?.description?.contains(msg) == true)
             }
         }
         return result

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultiInsertTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/datastore/DataStoreMultiInsertTest.kt
@@ -1426,4 +1426,39 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // find using syncstore, should return all items including the invalid one
         testSyncItemsList(true, StoreType.AUTO)
     }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testErrorMessageIfSameIdExistsNetwork() {
+        testErrorMessageIfSameIdExists(StoreType.NETWORK)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testErrorMessageIfSameIdExistsAuto() {
+        testErrorMessageIfSameIdExists(StoreType.AUTO)
+    }
+
+    @Test
+    @Ignore("Should work after fixing: https://kinvey.atlassian.net/browse/KDEV-781")
+    @Throws(InterruptedException::class)
+    fun testErrorMessageIfSameIdExistsSync() {
+        testErrorMessageIfSameIdExists(StoreType.SYNC)
+    }
+
+    @Throws(InterruptedException::class)
+    fun testErrorMessageIfSameIdExists(storeType: StoreType) {
+        val personList = createPersonsList(true)
+        val netStore = DataStore.collection(Person.COLLECTION, Person::class.java, storeType, client)
+        clearBackend(netStore)
+        var saveCallback = createList(netStore, personList)
+        assertNull(saveCallback.error)
+        assertNotNull(saveCallback.result)
+        assertTrue(checkPersonIfSameObjects(personList, saveCallback.result?.entities, false))
+        saveCallback = createList(netStore, personList)
+        assertNull(saveCallback.error)
+        assertNotNull(saveCallback.result?.errors)
+        assertNotNull(saveCallback.result?.errors?.get(0)?.description)
+        assertNotNull(saveCallback.result?.errors?.get(0)?.debug)
+    }
 }

--- a/java-api-core/src/com/kinvey/java/model/KinveyBatchInsertError.kt
+++ b/java-api-core/src/com/kinvey/java/model/KinveyBatchInsertError.kt
@@ -4,9 +4,6 @@ import com.google.api.client.util.Key
 
 data class KinveyBatchInsertError (
     @Key
-    var index: Int = 0,
-    @Key
-    var code: Long = 0,
-    @Key
-    var errorMessage: String? = null
-)
+    var index: Int = 0
+
+) : KinveyErrorResponse()

--- a/java-api-core/test/com/kinvey/java/model/KinveySaveBatchResponseTest.kt
+++ b/java-api-core/test/com/kinvey/java/model/KinveySaveBatchResponseTest.kt
@@ -15,7 +15,7 @@ class KinveySaveBatchResponseTest : TestCase() {
         assertTrue(response?.haveErrors == false)
 
         val entities = mutableListOf(Entity("test1"), Entity("test2"))
-        val errors = mutableListOf(KinveyBatchInsertError(0, 400, "test error"))
+        val errors = mutableListOf(KinveyBatchInsertError(0))
 
         response?.entities = entities
         response?.errors = errors

--- a/java-api-core/test/com/kinvey/java/model/KinveySyncSaveBatchResponseTest.kt
+++ b/java-api-core/test/com/kinvey/java/model/KinveySyncSaveBatchResponseTest.kt
@@ -8,7 +8,7 @@ class KinveySyncSaveBatchResponseTest : TestCase() {
     fun testConstructor() {
 
         val entities = listOf(Entity("test1"), Entity("test2"))
-        val errors = listOf(KinveyBatchInsertError(0, 400, "test error"))
+        val errors = listOf(KinveyBatchInsertError(0))
 
         response = KinveySyncSaveBatchResponse(entities, errors)
 


### PR DESCRIPTION
#### Description
The error message from the server is not returned, when some of the items fail.

#### Changes
Updated `KinveyBatchInsertError` class: removed `code` and `errorMessage` fields, now it extends `KinveyErrorResponse`, it adds `error`, `description`, `debug` fields. 

#### Tests
Instrumented.
