### PR TITLE
KDEV-784: Create function should support also a single item

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/BaseDataStoreMultiInsertTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/BaseDataStoreMultiInsertTest.kt
@@ -316,9 +316,9 @@ open class BaseDataStoreMultiInsertTest {
     }
 
     @Throws(InterruptedException::class)
-    protected fun <T : GenericJson> create(store: DataStore<T>, item: T): DefaultKinveyClientListCreateCallback<T> {
+    protected fun <T : GenericJson> create(store: DataStore<T>, item: T): DefaultKinveyClientCallback<T> {
         val latch = CountDownLatch(1)
-        val callback = DefaultKinveyClientListCreateCallback<T>(latch)
+        val callback = DefaultKinveyClientCallback<T>(latch)
         val looperThread = LooperThread(Runnable {
             store.create(item, callback)
         })

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/BaseDataStoreMultiInsertTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/BaseDataStoreMultiInsertTest.kt
@@ -1,4 +1,4 @@
-package com.kinvey.androidTest.store.datastore
+package com.kinvey.androidTest.store.data.multiinsert
 
 import android.os.Message
 import androidx.test.platform.app.InstrumentationRegistry
@@ -42,6 +42,7 @@ open class BaseDataStoreMultiInsertTest {
 
     companion object {
         const val TEST_USERNAME = "Test_UserName"
+        const val MULTI_INSERT_COLLECTION = "MultiInsertCollection"
         const val DEFAULT_TIMEOUT = 60
         const val MAX_PERSONS_COUNT = 5
         const val LONG_TIMEOUT = 6 * DEFAULT_TIMEOUT
@@ -307,6 +308,19 @@ open class BaseDataStoreMultiInsertTest {
             } catch (e: Exception) {
                 callback.onFailure(e)
             }
+        })
+        looperThread.start()
+        latch.await()
+        looperThread.mHandler?.sendMessage(Message())
+        return callback
+    }
+
+    @Throws(InterruptedException::class)
+    protected fun <T : GenericJson> create(store: DataStore<T>, item: T): DefaultKinveyClientListCreateCallback<T> {
+        val latch = CountDownLatch(1)
+        val callback = DefaultKinveyClientListCreateCallback<T>(latch)
+        val looperThread = LooperThread(Runnable {
+            store.create(item, callback)
         })
         looperThread.start()
         latch.await()
@@ -628,7 +642,7 @@ open class BaseDataStoreMultiInsertTest {
     fun <T : GenericJson> testCreateEmptyList(list: List<T>, cls: Class<T>, collection: String, storeType: StoreType) {
         val personStore = DataStore.collection(collection, cls, storeType, client)
         clearBackend(personStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = createList(personStore, list)
         Assert.assertNull(saveCallback.result)
@@ -642,7 +656,7 @@ open class BaseDataStoreMultiInsertTest {
     fun <T : GenericJson> testSaveEmptyList(list: List<T>, cls: Class<T>, collection: String, storeType: StoreType) {
         val personStore = DataStore.collection(collection, cls, storeType, client)
         clearBackend(personStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = saveList(personStore, list)
         Assert.assertNull(saveCallback.result)
@@ -662,13 +676,13 @@ open class BaseDataStoreMultiInsertTest {
 
         val personsList = createPersonsList(2, false)
 
-        val netManager = MockMultiInsertNetworkManager(Person.COLLECTION, Person::class.java, client as Client)
-        val personStore = DataStore(Person.COLLECTION, Person::class.java, client, storeType, netManager)
-        val storeSync = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.SYNC, netManager)
+        val netManager = MockMultiInsertNetworkManager(MULTI_INSERT_COLLECTION, Person::class.java, client as Client)
+        val personStore = DataStore(MULTI_INSERT_COLLECTION, Person::class.java, client, storeType, netManager)
+        val storeSync = DataStore(MULTI_INSERT_COLLECTION, Person::class.java, client, StoreType.SYNC, netManager)
 
         clearBackend(personStore)
         clearBackend(storeSync)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         personsList.onEach { item -> save(storeSync, item) }
 
@@ -678,7 +692,7 @@ open class BaseDataStoreMultiInsertTest {
         Assert.assertEquals(pushCallback.result?.successCount, personsList.count())
         Assert.assertTrue(netManager.useMultiInsertSave)
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         Assert.assertTrue(syncItems == null || syncItems.isEmpty())
 
         val findCallback = find(storeSync, LONG_TIMEOUT)
@@ -698,14 +712,14 @@ open class BaseDataStoreMultiInsertTest {
         val personList = createErrList2()
         val checkIndexesSuccess = intArrayOf(0, 2)
         val checkIndexesErr = intArrayOf(1)
-        val personStoreCurrent = DataStore.collection(Person.COLLECTION, Person::class.java, storeType, client)
-        val personStoreNet = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
-        val personStoreSync = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val personStoreCurrent = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, storeType, client)
+        val personStoreNet = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val personStoreSync = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
 
         clearBackend(personStoreCurrent)
         clearBackend(personStoreNet)
         clearBackend(personStoreSync)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         if (mockConnectionErr) {
             mockInvalidConnection()
@@ -726,7 +740,7 @@ open class BaseDataStoreMultiInsertTest {
             Assert.assertTrue(checkBatchResponseErrors(errorsList, checkIndexesErr, true, errMessages))
         }
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         Assert.assertNotNull(syncItems)
         Assert.assertEquals(syncItems?.count(), 1)
 

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreMultiInsertItemsOrderTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreMultiInsertItemsOrderTest.kt
@@ -1,4 +1,4 @@
-package com.kinvey.androidTest.store.datastore
+package com.kinvey.androidTest.store.data.multiinsert
 
 import androidx.test.filters.SmallTest
 import androidx.test.runner.AndroidJUnit4
@@ -39,9 +39,9 @@ class DataStoreMultiInsertItemsOrderTest : BaseDataStoreMultiInsertTest() {
 
         val personList = createCombineList()
 
-        val store = DataStore.collection(Person.COLLECTION, Person::class.java, storeType, client)
+        val store = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, storeType, client)
         clearBackend(store)
-        client.syncManager.clear(Person.COLLECTION)
+        client.syncManager.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = saveList(store, personList)
 

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreMultiInsertOfflinePushTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreMultiInsertOfflinePushTest.kt
@@ -1,4 +1,4 @@
-package com.kinvey.androidTest.store.datastore
+package com.kinvey.androidTest.store.data.multiinsert
 
 import androidx.test.filters.SmallTest
 import androidx.test.runner.AndroidJUnit4
@@ -20,15 +20,15 @@ class DataStoreMultiInsertOfflinePushTest : BaseDataStoreMultiInsertTest() {
         print("should push item with connectivity error")
 
         val person = Person(TEST_USERNAME)
-        val autoStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.AUTO, client)
+        val autoStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.AUTO, client)
         clearBackend(autoStore)
-        client.syncManager.clear(Person.COLLECTION)
+        client.syncManager.clear(MULTI_INSERT_COLLECTION)
 
         mockInvalidConnection()
         val saveResult = save(autoStore, person)
         val pushResult = push(autoStore, LONG_TIMEOUT)
         cancelMockInvalidConnection()
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
 
         assertNotNull(syncItems)
         assertEquals(1, syncItems?.count())
@@ -43,12 +43,12 @@ class DataStoreMultiInsertOfflinePushTest : BaseDataStoreMultiInsertTest() {
         print("should push item with connectivity error and store item in local cache")
 
         val person = Person(TEST_USERNAME)
-        val autoStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.AUTO, client)
-        val syncStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val autoStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.AUTO, client)
+        val syncStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
 
         clearBackend(syncStore)
         clearBackend(autoStore)
-        client.syncManager.clear(Person.COLLECTION)
+        client.syncManager.clear(MULTI_INSERT_COLLECTION)
 
         mockInvalidConnection()
         val saveResult = save(autoStore, person)
@@ -60,7 +60,7 @@ class DataStoreMultiInsertOfflinePushTest : BaseDataStoreMultiInsertTest() {
         assertNull(findResult.error)
         assertEquals(1, findResult.result?.result?.count())
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertNotNull(syncItems)
         assertEquals(1, syncItems?.count())
     
@@ -74,15 +74,15 @@ class DataStoreMultiInsertOfflinePushTest : BaseDataStoreMultiInsertTest() {
         print("should save item in local cache")
 
         val person = Person(TEST_USERNAME)
-        val autoStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.AUTO, client)
+        val autoStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.AUTO, client)
         clearBackend(autoStore)
-        client.syncManager.clear(Person.COLLECTION)
+        client.syncManager.clear(MULTI_INSERT_COLLECTION)
 
         mockInvalidConnection()
         val saveResult = save(autoStore, person)
         cancelMockInvalidConnection()
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertNotNull(syncItems)
         assertEquals(1, syncItems?.count())
 

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreMultiInsertTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreMultiInsertTest.kt
@@ -1,4 +1,4 @@
-package com.kinvey.androidTest.store.datastore
+package com.kinvey.androidTest.store.data.multiinsert
 
 import androidx.test.filters.LargeTest
 import androidx.test.runner.AndroidJUnit4
@@ -53,9 +53,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
     fun createMultiInsertList(storeType: StoreType) {
         val personList = createPersonsList(false)
 
-        val personStore = DataStore.collection(Person.COLLECTION, Person::class.java, storeType, client)
+        val personStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, storeType, client)
         clearBackend(personStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = createList(personStore, personList)
         assertNull(saveCallback.error)
@@ -81,9 +81,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
     fun createMultiListWithId() {
         val personList = createPersonsList(true)
 
-        val personStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val personStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
         clearBackend(personStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = createList(personStore, personList)
         assertNull(saveCallback.error)
@@ -116,17 +116,17 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
     fun testCreateListCombineWithIdAndWithoutIdSync() {
         val personList = createCombineList()
 
-        val syncStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val syncStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
 
         clearBackend(syncStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = createList(syncStore, personList)
         assertNull(saveCallback.error)
         assertNotNull(saveCallback.result)
         assertTrue(checkPersonIfSameObjects(personList, saveCallback.result?.entities, false))
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertNotNull(syncItems)
         assertEquals(syncItems!!.size.toLong(), personList.size.toLong())
         assertEquals(syncItems[0].requestMethod, SyncRequest.HttpVerb.POST)
@@ -144,15 +144,15 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
     fun testCreateListCombineWithIdAndWithoutIdAuto() {
         val personList = createCombineList()
 
-        val mockNetManager = MockMultiInsertNetworkManager(Person.COLLECTION, Person::class.java, client as Client)
-        val autoStore = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.AUTO, mockNetManager)
-        val syncStore = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.SYNC, mockNetManager)
-        val netStore = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.NETWORK, mockNetManager)
+        val mockNetManager = MockMultiInsertNetworkManager(MULTI_INSERT_COLLECTION, Person::class.java, client as Client)
+        val autoStore = DataStore(MULTI_INSERT_COLLECTION, Person::class.java, client, StoreType.AUTO, mockNetManager)
+        val syncStore = DataStore(MULTI_INSERT_COLLECTION, Person::class.java, client, StoreType.SYNC, mockNetManager)
+        val netStore = DataStore(MULTI_INSERT_COLLECTION, Person::class.java, client, StoreType.NETWORK, mockNetManager)
 
         clearBackend(autoStore)
         clearBackend(syncStore)
         clearBackend(netStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         mockNetManager.clear()
         val saveCallback = createList(autoStore, personList)
@@ -174,7 +174,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
     @Throws(InterruptedException::class)
     fun testCreateListReturnErrorForEmptyListSync() {
         val list = ArrayList<Person>()
-        testCreateEmptyList(list, Person::class.java, Person.COLLECTION, StoreType.SYNC)
+        testCreateEmptyList(list, Person::class.java, MULTI_INSERT_COLLECTION, StoreType.SYNC)
     }
 
     @Test
@@ -182,9 +182,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
     fun <T : GenericJson> testCreateApiV6() {
         val personList = createPersonsList(false)
         kinveyApiVersion = "6"
-        val personStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val personStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
         clearBackend(personStore)
-        client.syncManager.clear(Person.COLLECTION)
+        client.syncManager.clear(MULTI_INSERT_COLLECTION)
         val saveCallback = createList(personStore, personList)
         assertNull(saveCallback.error)
         assertNotNull(saveCallback.result)
@@ -203,9 +203,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // call save() with it
         // find using network store
 
-        val netStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val netStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
         clearBackend(netStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val person = createPerson(TEST_USERNAME)
         val saveCallback = save(netStore, person)
@@ -233,9 +233,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // call save() with it
         // find using network store
 
-        val netStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val netStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
         clearBackend(netStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val id = "123456"
         val person = createPerson(TEST_USERNAME)
@@ -267,9 +267,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
 
         val personList = createPersonsList(false)
 
-        val personStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val personStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
         clearBackend(personStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = saveList(personStore, personList)
         assertNull(saveCallback.error)
@@ -291,9 +291,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
 
         val personList = createPersonsList(true)
 
-        val personStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val personStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
         clearBackend(personStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = saveList(personStore, personList)
         assertNull(saveCallback.error)
@@ -315,9 +315,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
 
         val personList = createCombineList()
 
-        val personStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val personStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
         clearBackend(personStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = saveList(personStore, personList)
         assertNull(saveCallback.error)
@@ -336,7 +336,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // create an empty array
         // save() using the array
         val list = ArrayList<Person>()
-        testSaveEmptyList(list, Person::class.java, Person.COLLECTION, StoreType.NETWORK)
+        testSaveEmptyList(list, Person::class.java, MULTI_INSERT_COLLECTION, StoreType.NETWORK)
     }
 
     @Test
@@ -366,7 +366,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         val personList = createErrList()
         val checkIndexes = intArrayOf(0, 1)
 
-        val personStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val personStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
         clearBackend(personStore)
 
         val saveCallback = saveList(personStore, personList)
@@ -393,7 +393,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         val checkIndexesSuccess = intArrayOf(0)
         val checkIndexesErr = intArrayOf(1)
 
-        val personStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val personStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
         clearBackend(personStore)
 
         val saveCallback = saveList(personStore, personList)
@@ -424,7 +424,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         val checkIndexesSuccess = intArrayOf(1, 3)
         val checkIndexesErr = intArrayOf(0, 2)
 
-        val personStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val personStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
         clearBackend(personStore)
 
         val saveCallback = saveList(personStore, personList)
@@ -454,9 +454,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // pendingSyncEntities()
         // find() using sync store
 
-        val syncStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val syncStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
         clearBackend(syncStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val person = createPerson(TEST_USERNAME)
 
@@ -467,7 +467,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         assertNotNull(resultPerson.id)
         assertEquals(person.username, resultPerson.username)
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertNotNull(syncItems)
         assertEquals(syncItems?.count(), 1)
         assertEquals(syncItems?.get(0)?.requestMethod, SyncRequest.HttpVerb.POST)
@@ -491,9 +491,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // pendingSyncEntities()
         // find() using syncstore
 
-        val syncStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val syncStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
         clearBackend(syncStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val id = "123456"
         val person = createPerson(TEST_USERNAME)
@@ -506,7 +506,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         assertNotNull(resultPerson)
         assertEquals(id, resultPerson.id)
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertNotNull(syncItems)
         assertEquals(syncItems?.count(), 1)
         assertEquals(syncItems?.get(0)?.requestMethod, SyncRequest.HttpVerb.PUT)
@@ -531,17 +531,17 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
 
         val personList = createPersonsList(false)
 
-        val syncStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val syncStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
 
         clearBackend(syncStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = saveList(syncStore, personList)
         assertNull(saveCallback.error)
         assertNotNull(saveCallback.result)
         assertTrue(checkPersonIfSameObjects(personList, saveCallback.result, false))
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertNotNull(syncItems)
         assertTrue(checkSyncItems<GenericJson>(syncItems, personList.size, SyncRequest.HttpVerb.POST))
 
@@ -561,17 +561,17 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
 
         val personList = createPersonsList(true)
 
-        val syncStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val syncStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
 
         clearBackend(syncStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = saveList(syncStore, personList)
         assertNull(saveCallback.error)
         assertNotNull(saveCallback.result)
         assertTrue(checkPersonIfSameObjects(personList, saveCallback.result, false))
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertNotNull(syncItems)
         assertTrue(checkSyncItems<GenericJson>(syncItems, personList.size, SyncRequest.HttpVerb.PUT))
 
@@ -590,17 +590,17 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // find() using syncstore, should return the items from step 1 with _ids of the items that were assigned
         val personList = createCombineList()
 
-        val syncStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val syncStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
 
         clearBackend(syncStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = saveList(syncStore, personList)
         assertNull(saveCallback.error)
         assertNotNull(saveCallback.result)
         assertTrue(checkPersonIfSameObjects(personList, saveCallback.result, false))
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertNotNull(syncItems)
         assertEquals(syncItems!!.size.toLong(), personList.size.toLong())
         assertEquals(syncItems[0].requestMethod, SyncRequest.HttpVerb.POST)
@@ -620,7 +620,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // create an empty array
         // save() using the array
         val list = ArrayList<Person>()
-        testSaveEmptyList(list, Person::class.java, Person.COLLECTION, StoreType.SYNC)
+        testSaveEmptyList(list, Person::class.java, MULTI_INSERT_COLLECTION, StoreType.SYNC)
     }
 
     @Test
@@ -634,9 +634,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // find using syncstore, should return the items with ect and lmt
         val personsList = createPersonsList(false)
 
-        val storeSync = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val storeSync = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
         clearBackend(storeSync)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallbackSecond = saveList(storeSync, personsList)
         assertNull(saveCallbackSecond.error)
@@ -647,7 +647,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         assertNotNull(pushCallback.result)
         assertEquals(personsList.count(), pushCallback.result?.successCount)
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertTrue(syncItems.isNullOrEmpty())
 
         val findCallback = find(storeSync, LONG_TIMEOUT)
@@ -666,9 +666,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // find using syncstore, should return the items with ect and lmt
         val personsList = createCombineList()
 
-        val storeSync = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val storeSync = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
         clearBackend(storeSync)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallbackSecond = saveList(storeSync, personsList)
         assertNull(saveCallbackSecond.error)
@@ -679,7 +679,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         assertNotNull(pushCallback.result)
         assertEquals(personsList.count(), pushCallback.result?.successCount)
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertTrue(syncItems.isNullOrEmpty())
 
         val findCallback = find(storeSync, LONG_TIMEOUT)
@@ -698,10 +698,10 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // find using syncstore, should return the items with ect and lmt
         val personsList = createCombineList()
 
-        val mockNetManager = MockMultiInsertNetworkManager(Person.COLLECTION, Person::class.java, client as Client)
-        val storeSync = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.SYNC, mockNetManager)
+        val mockNetManager = MockMultiInsertNetworkManager(MULTI_INSERT_COLLECTION, Person::class.java, client as Client)
+        val storeSync = DataStore(MULTI_INSERT_COLLECTION, Person::class.java, client, StoreType.SYNC, mockNetManager)
         clearBackend(storeSync)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         saveList(storeSync, personsList)
 
@@ -710,7 +710,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         assertEquals(personsList.count(), pushCallback.result?.successCount)
         assertTrue(mockNetManager.useMultiInsertSave)
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertTrue(syncItems == null || syncItems.isEmpty())
 
         val findCallback = find(storeSync, LONG_TIMEOUT)
@@ -774,9 +774,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         val personsList = createPushErrList()
         val successItemsIdx = intArrayOf(2)
 
-        val storeSync = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val storeSync = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
         clearBackend(storeSync)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         saveList(storeSync, personsList)
 
@@ -784,7 +784,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         assertNotNull(pushCallback.result)
         assertEquals(1, pushCallback.result?.successCount)
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertNotNull(syncItems)
         assertTrue(checkSyncItems<GenericJson>(syncItems, 2, SyncRequest.HttpVerb.POST))
 
@@ -830,13 +830,13 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // call find() with sync store
         // find using network store
 
-        val autoStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.AUTO, client)
-        val syncStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
-        val netStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val autoStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.AUTO, client)
+        val syncStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val netStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
         clearBackend(autoStore)
         clearBackend(syncStore)
         clearBackend(netStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val person = createPerson(TEST_USERNAME)
 
@@ -875,13 +875,13 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // call find() with syncstore
         // find using networkstore
 
-        val autoStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.AUTO, client)
-        val syncStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
-        val netStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val autoStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.AUTO, client)
+        val syncStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val netStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
         clearBackend(autoStore)
         clearBackend(syncStore)
         clearBackend(netStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val id = "123456"
         val person = createPerson(TEST_USERNAME)
@@ -923,11 +923,11 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         val person = Person(TEST_USERNAME)
         person.geoloc = ERR_GEOLOC
 
-        val autoStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.AUTO, client)
-        val syncStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val autoStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.AUTO, client)
+        val syncStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
         clearBackend(autoStore)
         clearBackend(syncStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         mockInvalidConnection()
         save(autoStore, person)
@@ -939,7 +939,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         assertEquals(1, list?.count())
         assertNotNull(list?.get(0)?.id)
 
-        val pendingList = pendingSyncEntities(Person.COLLECTION)
+        val pendingList = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertNotNull(pendingList)
         assertEquals(1, pendingList?.count())
         val item = pendingList?.get(0)
@@ -958,11 +958,11 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         val testId = "TEST_ID_123"
         val person = Person(testId, TEST_USERNAME)
 
-        val autoStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.AUTO, client)
-        val syncStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val autoStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.AUTO, client)
+        val syncStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
         clearBackend(autoStore)
         clearBackend(syncStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         mockInvalidConnection()
         save(autoStore, person)
@@ -974,7 +974,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         assertEquals(1, list?.count())
         assertEquals(testId, list?.get(0)?.id)
 
-        val pendingList = pendingSyncEntities(Person.COLLECTION)
+        val pendingList = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertNotNull(pendingList)
         assertEquals(1, pendingList?.count())
         val item = pendingList?.get(0)
@@ -994,13 +994,13 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
 
         val personList = createPersonsList(false)
 
-        val autoStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.AUTO, client)
-        val syncStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
-        val netStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val autoStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.AUTO, client)
+        val syncStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val netStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
         clearBackend(autoStore)
         clearBackend(syncStore)
         clearBackend(netStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = saveList(autoStore, personList)
         assertNull(saveCallback.error)
@@ -1026,11 +1026,11 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
 
         val personList = createPersonsList(true)
 
-        val autoStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.AUTO, client)
-        val netStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val autoStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.AUTO, client)
+        val netStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
         clearBackend(autoStore)
         clearBackend(netStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = saveList(autoStore, personList)
         assertNull(saveCallback.error)
@@ -1053,15 +1053,15 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
 
         val personList = createCombineList()
 
-        val mockNetManager = MockMultiInsertNetworkManager(Person.COLLECTION, Person::class.java, client as Client)
-        val autoStore = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.AUTO, mockNetManager)
-        val syncStore = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.SYNC, mockNetManager)
-        val netStore = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.NETWORK, mockNetManager)
+        val mockNetManager = MockMultiInsertNetworkManager(MULTI_INSERT_COLLECTION, Person::class.java, client as Client)
+        val autoStore = DataStore(MULTI_INSERT_COLLECTION, Person::class.java, client, StoreType.AUTO, mockNetManager)
+        val syncStore = DataStore(MULTI_INSERT_COLLECTION, Person::class.java, client, StoreType.SYNC, mockNetManager)
+        val netStore = DataStore(MULTI_INSERT_COLLECTION, Person::class.java, client, StoreType.NETWORK, mockNetManager)
 
         clearBackend(autoStore)
         clearBackend(syncStore)
         clearBackend(netStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         mockNetManager.clear()
         val saveCallback = saveList(autoStore, personList)
@@ -1087,9 +1087,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // save() using the array
         // pendingSyncEntities()
         val list = ArrayList<Person>()
-        testSaveEmptyList(list, Person::class.java, Person.COLLECTION, StoreType.AUTO)
+        testSaveEmptyList(list, Person::class.java, MULTI_INSERT_COLLECTION, StoreType.AUTO)
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         val pendingCount = syncItems?.size ?: 0
         //assertNotNull(syncItems);
         assertEquals(pendingCount.toLong(), list.size.toLong())
@@ -1139,11 +1139,11 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         val personList = createErrList()
         val checkIndexes = intArrayOf(0, 1)
 
-        val autoStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.AUTO, client)
-        val syncStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val autoStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.AUTO, client)
+        val syncStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
         clearBackend(autoStore)
         clearBackend(syncStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = saveList(autoStore, personList)
         assertNotNull(saveCallback.error)
@@ -1159,7 +1159,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         assertNotNull(findCallback.result)
         assertTrue(checkPersonIfSameObjects(personList, findCallback.result?.result))
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertNotNull(syncItems)
         assertTrue(checkSyncItems<GenericJson>(syncItems, personList.size, SyncRequest.HttpVerb.POST))
     }
@@ -1178,13 +1178,13 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         val checkIndexesSuccess = intArrayOf(0)
         val checkIndexesErr = intArrayOf(1)
 
-        val autoStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.AUTO, client)
-        val syncStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
-        val netStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val autoStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.AUTO, client)
+        val syncStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val netStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
         clearBackend(autoStore)
         clearBackend(syncStore)
         clearBackend(netStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = saveList(autoStore, personList)
         assertNotNull(saveCallback.error)
@@ -1197,7 +1197,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
             assertTrue(checkBatchResponseErrors(errorsList, checkIndexesErr, true, errMessages))
         }
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertNotNull(syncItems)
         assertTrue(checkSyncItems<GenericJson>(syncItems, 1, SyncRequest.HttpVerb.POST))
 
@@ -1224,11 +1224,11 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         val checkIndexesSuccess = intArrayOf(1, 3)
         val checkIndexesErr = intArrayOf(0, 2)
 
-        val autoStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.AUTO, client)
-        val syncStore = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.SYNC, client)
+        val autoStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.AUTO, client)
+        val syncStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
         clearBackend(autoStore)
         clearBackend(syncStore)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         val saveCallback = saveList(autoStore, personList)
         assertNotNull(saveCallback.error)
@@ -1241,7 +1241,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
             assertTrue(checkBatchResponseErrors(errorsList, checkIndexesErr, true, errMessages))
         }
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertNotNull(syncItems)
         syncItems?.let { sItems ->
             assertEquals(sItems[0].requestMethod, SyncRequest.HttpVerb.POST)
@@ -1263,11 +1263,11 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // find() using networkstore : should return the items from step 1
         val personsList = createPersonsList(false)
 
-        val storeNet = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
-        val storeAuto = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.AUTO, client)
+        val storeNet = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val storeAuto = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.AUTO, client)
         clearBackend(storeNet)
         clearBackend(storeAuto)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         mockInvalidConnection()
         saveList(storeAuto, personsList)
@@ -1277,7 +1277,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         assertNotNull(pushCallback.result)
         assertEquals(pushCallback.result?.successCount, personsList.count())
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertTrue(syncItems.isNullOrEmpty())
 
         val findCallback = find(storeNet, LONG_TIMEOUT)
@@ -1296,11 +1296,11 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // find() using networkstore, should return the items from step 1
         val personsList = createCombineList()
 
-        val autoSync = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.AUTO, client)
-        val netSync = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        val autoSync = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.AUTO, client)
+        val netSync = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
         clearBackend(autoSync)
         clearBackend(netSync)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         mockInvalidConnection()
         saveList(autoSync, personsList)
@@ -1310,7 +1310,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         assertNotNull(pushCallback.result)
         assertEquals(personsList.count(), pushCallback.result?.successCount)
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertTrue(syncItems.isNullOrEmpty())
 
         val findCallback = find(netSync, LONG_TIMEOUT)
@@ -1329,13 +1329,13 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         // find() using networkstore, should return the items from step 1
         val personsList = createCombineList()
 
-        val mockNetManager = MockMultiInsertNetworkManager(Person.COLLECTION, Person::class.java, client as Client)
-        val autoSync = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.AUTO, mockNetManager)
-        val netSync = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.NETWORK, mockNetManager)
+        val mockNetManager = MockMultiInsertNetworkManager(MULTI_INSERT_COLLECTION, Person::class.java, client as Client)
+        val autoSync = DataStore(MULTI_INSERT_COLLECTION, Person::class.java, client, StoreType.AUTO, mockNetManager)
+        val netSync = DataStore(MULTI_INSERT_COLLECTION, Person::class.java, client, StoreType.NETWORK, mockNetManager)
 
         clearBackend(autoSync)
         clearBackend(netSync)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         mockInvalidConnection()
         saveList(autoSync, personsList)
@@ -1346,7 +1346,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         assertEquals(personsList.count(), pushCallback.result?.successCount)
         assertTrue(mockNetManager.useMultiInsertSave)
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertTrue(syncItems.isNullOrEmpty())
 
         val findCallback = find(netSync, LONG_TIMEOUT)
@@ -1401,9 +1401,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
 
         val personsList = createPushErrList()
 
-        val autoSync = DataStore.collection(Person.COLLECTION, Person::class.java, StoreType.AUTO, client)
+        val autoSync = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.AUTO, client)
         clearBackend(autoSync)
-        client?.syncManager?.clear(Person.COLLECTION)
+        client?.syncManager?.clear(MULTI_INSERT_COLLECTION)
 
         mockInvalidConnection()
         saveList(autoSync, personsList)
@@ -1413,7 +1413,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         assertNotNull(pushCallback.result)
         assertEquals(personsList.count(), pushCallback.result?.successCount)
 
-        val syncItems = pendingSyncEntities(Person.COLLECTION)
+        val syncItems = pendingSyncEntities(MULTI_INSERT_COLLECTION)
         assertNotNull(syncItems)
         assertTrue(checkSyncItems<GenericJson>(syncItems, 2, SyncRequest.HttpVerb.PUT))
     }
@@ -1471,9 +1471,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
     @Throws(InterruptedException::class)
     private fun testTempId(storeType: StoreType) {
         val personList = createPersonsList(false)
-        val personStore = DataStore.collection(Person.COLLECTION, Person::class.java, storeType, client)
+        val personStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, storeType, client)
         clearBackend(personStore)
-        client.syncManager.clear(Person.COLLECTION)
+        client.syncManager.clear(MULTI_INSERT_COLLECTION)
         val saveCallback = createList(personStore, personList)
         assertNull(saveCallback.error)
         assertNotNull(saveCallback.result)
@@ -1519,7 +1519,7 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
     @Throws(InterruptedException::class)
     fun testErrorMessageIfSameIdExists(storeType: StoreType) {
         val personList = createPersonsList(true)
-        val netStore = DataStore.collection(Person.COLLECTION, Person::class.java, storeType, client)
+        val netStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, storeType, client)
         clearBackend(netStore)
         var saveCallback = createList(netStore, personList)
         assertNull(saveCallback.error)

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreMultipleMultiInsertTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreMultipleMultiInsertTest.kt
@@ -1,4 +1,4 @@
-package com.kinvey.androidTest.store.datastore
+package com.kinvey.androidTest.store.data.multiinsert
 
 import androidx.test.filters.SmallTest
 import androidx.test.runner.AndroidJUnit4
@@ -22,10 +22,10 @@ class DataStoreMultipleMultiInsertTest : BaseDataStoreMultiInsertTest() {
     @Throws(InterruptedException::class)
     fun testSaveMultipleBatchRequests() {
         print("should send multiple multi-insert POST requests")
-        val netManager = MockMultiInsertNetworkManager(Person.COLLECTION, Person::class.java, client)
-        val store = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.NETWORK, netManager)
+        val netManager = MockMultiInsertNetworkManager(MULTI_INSERT_COLLECTION, Person::class.java, client)
+        val store = DataStore(MULTI_INSERT_COLLECTION, Person::class.java, client, StoreType.NETWORK, netManager)
         clearBackend(store)
-        client.syncManager.clear(Person.COLLECTION)
+        client.syncManager.clear(MULTI_INSERT_COLLECTION)
 
         val itemsList = createPersonsList(200, false)
 
@@ -40,10 +40,10 @@ class DataStoreMultipleMultiInsertTest : BaseDataStoreMultiInsertTest() {
     @Throws(InterruptedException::class)
     fun testSaveMultipleBatchRequestsIfWasErrors() {
         print("should send multiple multi-insert POST requests, if was errors then should return empty array and array of errors")
-        val netManager = MockMultiInsertNetworkManager(Person.COLLECTION, Person::class.java, client)
-        val store = DataStore(Person.COLLECTION, Person::class.java, client, StoreType.NETWORK, netManager)
+        val netManager = MockMultiInsertNetworkManager(MULTI_INSERT_COLLECTION, Person::class.java, client)
+        val store = DataStore(MULTI_INSERT_COLLECTION, Person::class.java, client, StoreType.NETWORK, netManager)
         clearBackend(store)
-        client.syncManager.clear(Person.COLLECTION)
+        client.syncManager.clear(MULTI_INSERT_COLLECTION)
         val itemsList = createPersonsListErr(200, 50, 50)
         val saveCallback = saveList(store, itemsList)
         assertNotNull(saveCallback.result)

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreSingleInsertTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreSingleInsertTest.kt
@@ -3,20 +3,16 @@ package com.kinvey.androidTest.store.data.multiinsert
 import androidx.test.filters.LargeTest
 import androidx.test.runner.AndroidJUnit4
 import com.google.api.client.json.GenericJson
-import com.kinvey.android.Client
 import com.kinvey.android.store.DataStore
 import com.kinvey.androidTest.model.EntitySet
 import com.kinvey.androidTest.model.Person
-import com.kinvey.androidTest.network.MockMultiInsertNetworkManager
-import com.kinvey.java.KinveySaveBatchException
 import com.kinvey.java.core.KinveyJsonResponseException
 import com.kinvey.java.store.StoreType
-import com.kinvey.java.sync.dto.SyncRequest
 import com.kinvey.java.AbstractClient.Companion.kinveyApiVersion
 import com.kinvey.java.Constants._ID
+import org.junit.Assert
 
 
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -25,7 +21,7 @@ import java.util.ArrayList
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
+import org.junit.Ignore
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
@@ -62,6 +58,9 @@ class DataStoreSingleInsertTest : BaseDataStoreMultiInsertTest() {
         val saveCallback = create(personStore, person)
         assertNull(saveCallback.error)
         assertNotNull(saveCallback.result)
+        assertNotNull(saveCallback.result!!.entities)
+        assertEquals(1, saveCallback.result!!.entities!!.size)
+        assertEquals(person.username, saveCallback.result!!.entities!![0].username)
 
         val findCallback = find(personStore, LONG_TIMEOUT)
         assertNotNull(findCallback.result)
@@ -84,7 +83,6 @@ class DataStoreSingleInsertTest : BaseDataStoreMultiInsertTest() {
         val person = createPerson(TEST_USERNAME)
         val personStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
         clearBackend(personStore)
-        client.syncManager.clear(MULTI_INSERT_COLLECTION)
         person[_ID] = "123"
         val saveCallback =  create(personStore, person)
         assertNull(saveCallback.error)
@@ -110,5 +108,114 @@ class DataStoreSingleInsertTest : BaseDataStoreMultiInsertTest() {
         clearBackend(personStore)
         kinveyApiVersion = "5"
     }
-   
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testCreateWithoutId() {
+        val netStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        clearBackend(netStore)
+        val person = createPerson(TEST_USERNAME)
+        val saveCallback = create(netStore, person)
+        assertNotNull(saveCallback.result)
+        assertNull(saveCallback.error)
+        val resultPerson = saveCallback.result?.entities?.get(0) as Person
+        assertNotNull(resultPerson.id)
+        assertEquals(person.username, resultPerson.username)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testCreateListReturnErrorForInvalidCredentialsNetwork() {
+        val store = DataStore.collection(EntitySet.COLLECTION, EntitySet::class.java, StoreType.NETWORK, client)
+        clearBackend(store)
+        val entity = EntitySet()
+        entity.description = "entity 1"
+        val defaultKinveyListCallback = create(store, entity)
+        assertNotNull(defaultKinveyListCallback.error)
+        assertEquals(defaultKinveyListCallback.error?.javaClass, KinveyJsonResponseException::class.java)
+    }
+
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testTempIdSync() {
+        testTempId(StoreType.SYNC)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testTempIdCache() {
+        testTempId(StoreType.CACHE)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testTempIdAuto() {
+        testTempId(StoreType.AUTO)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testTempIdNetwork() {
+        testTempId(StoreType.NETWORK)
+    }
+
+    @Throws(InterruptedException::class)
+    private fun testTempId(storeType: StoreType) {
+        val person = createPerson(TEST_USERNAME)
+        val personStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, storeType, client)
+        clearBackend(personStore)
+        client.syncManager.clear(MULTI_INSERT_COLLECTION)
+        val saveCallback = create(personStore, person)
+        assertNull(saveCallback.error)
+        assertNotNull(saveCallback.result)
+        assertNotNull(saveCallback.result!!.entities)
+        if (storeType == StoreType.SYNC) {
+            Assert.assertTrue(saveCallback.result!!.entities?.get(0)?.id?.startsWith("temp")!!)
+            val pushCallback = push(personStore, DEFAULT_TIMEOUT)
+            assertNull(pushCallback.error)
+            assertNotNull(pushCallback.result)
+        } else {
+            Assert.assertTrue(saveCallback.result!!.entities?.get(0)?.id?.startsWith("temp")!!)
+        }
+        val findCallback = find(personStore, LONG_TIMEOUT)
+        assertNotNull(findCallback.result)
+        assertNotNull(findCallback.result!!.result)
+        Assert.assertTrue(!saveCallback.result!!.entities?.get(0)?.id?.startsWith("temp")!!)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testErrorMessageIfSameIdExistsNetwork() {
+        testErrorMessageIfSameIdExists(StoreType.NETWORK)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testErrorMessageIfSameIdExistsAuto() {
+        testErrorMessageIfSameIdExists(StoreType.AUTO)
+    }
+
+    @Test
+    @Ignore("Should work after fixing: https://kinvey.atlassian.net/browse/KDEV-781")
+    @Throws(InterruptedException::class)
+    fun testErrorMessageIfSameIdExistsSync() {
+        testErrorMessageIfSameIdExists(StoreType.SYNC)
+    }
+
+    @Throws(InterruptedException::class)
+    fun testErrorMessageIfSameIdExists(storeType: StoreType) {
+        val personList = createPersonsList(true)
+        val netStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, storeType, client)
+        clearBackend(netStore)
+        var saveCallback = createList(netStore, personList)
+        assertNull(saveCallback.error)
+        assertNotNull(saveCallback.result)
+        Assert.assertTrue(checkPersonIfSameObjects(personList, saveCallback.result?.entities, false))
+        saveCallback = createList(netStore, personList)
+        assertNull(saveCallback.error)
+        assertNotNull(saveCallback.result?.errors)
+        assertNotNull(saveCallback.result?.errors?.get(0)?.description)
+        assertNotNull(saveCallback.result?.errors?.get(0)?.debug)
+    }
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreSingleInsertTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreSingleInsertTest.kt
@@ -1,0 +1,114 @@
+package com.kinvey.androidTest.store.data.multiinsert
+
+import androidx.test.filters.LargeTest
+import androidx.test.runner.AndroidJUnit4
+import com.google.api.client.json.GenericJson
+import com.kinvey.android.Client
+import com.kinvey.android.store.DataStore
+import com.kinvey.androidTest.model.EntitySet
+import com.kinvey.androidTest.model.Person
+import com.kinvey.androidTest.network.MockMultiInsertNetworkManager
+import com.kinvey.java.KinveySaveBatchException
+import com.kinvey.java.core.KinveyJsonResponseException
+import com.kinvey.java.store.StoreType
+import com.kinvey.java.sync.dto.SyncRequest
+import com.kinvey.java.AbstractClient.Companion.kinveyApiVersion
+import com.kinvey.java.Constants._ID
+
+
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import java.util.ArrayList
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class DataStoreSingleInsertTest : BaseDataStoreMultiInsertTest() {
+
+    // CREATE METHOD TESTS
+    @Test
+    @Throws(InterruptedException::class)
+    fun createSingleInsertNetwork() {
+        client.enableDebugLogging()
+        createSingleInsert(StoreType.NETWORK)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun createSingleInsertAuto() {
+        createSingleInsert(StoreType.AUTO)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun createSingleInsertSync() {
+        createSingleInsert(StoreType.SYNC)
+    }
+
+    @Throws(InterruptedException::class)
+    fun createSingleInsert(storeType: StoreType) {
+        val person = createPerson(TEST_USERNAME)
+
+        val personStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, storeType, client)
+        clearBackend(personStore)
+        client.syncManager.clear(MULTI_INSERT_COLLECTION)
+
+        val saveCallback = create(personStore, person)
+        assertNull(saveCallback.error)
+        assertNotNull(saveCallback.result)
+
+        val findCallback = find(personStore, LONG_TIMEOUT)
+        assertNotNull(findCallback.result)
+        assertEquals(person.username, findCallback.result!!.result!![0].username)
+        val personListSecond = ArrayList<Person>()
+        personListSecond.addAll(findCallback.result?.result!!)
+        personListSecond.add(Person())
+        val saveCallbackSecond = createList(personStore, personListSecond)
+        assertNull(saveCallbackSecond.error)
+        assertNotNull(saveCallbackSecond.result)
+        if (storeType != StoreType.SYNC) {
+            assertNotNull(saveCallbackSecond.result?.errors)
+            assertEquals(1, saveCallbackSecond.result?.errors?.size)
+        }
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun createWithId() {
+        val person = createPerson(TEST_USERNAME)
+        val personStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.NETWORK, client)
+        clearBackend(personStore)
+        client.syncManager.clear(MULTI_INSERT_COLLECTION)
+        person[_ID] = "123"
+        val saveCallback =  create(personStore, person)
+        assertNull(saveCallback.error)
+        assertNotNull(saveCallback.result)
+        val findCallback = find(personStore, LONG_TIMEOUT)
+        assertNotNull(findCallback.result)
+        assertEquals(person.username, findCallback.result?.result!![0].username)
+        assertEquals(person.id, findCallback.result?.result!![0].id)
+        assertEquals("123", findCallback.result?.result!![0].id)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun <T : GenericJson> testCreateApiV6() {
+        val person = createPerson(TEST_USERNAME)
+        kinveyApiVersion = "6"
+        val personStore = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.SYNC, client)
+        clearBackend(personStore)
+        client.syncManager.clear(MULTI_INSERT_COLLECTION)
+        val saveCallback = create(personStore, person)
+        assertNull(saveCallback.error)
+        assertNotNull(saveCallback.result)
+        clearBackend(personStore)
+        kinveyApiVersion = "5"
+    }
+   
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreSingleInsertTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreSingleInsertTest.kt
@@ -58,9 +58,7 @@ class DataStoreSingleInsertTest : BaseDataStoreMultiInsertTest() {
         val saveCallback = create(personStore, person)
         assertNull(saveCallback.error)
         assertNotNull(saveCallback.result)
-        assertNotNull(saveCallback.result!!.entities)
-        assertEquals(1, saveCallback.result!!.entities!!.size)
-        assertEquals(person.username, saveCallback.result!!.entities!![0].username)
+        assertEquals(person.username, saveCallback.result!!.username)
 
         val findCallback = find(personStore, LONG_TIMEOUT)
         assertNotNull(findCallback.result)
@@ -118,7 +116,7 @@ class DataStoreSingleInsertTest : BaseDataStoreMultiInsertTest() {
         val saveCallback = create(netStore, person)
         assertNotNull(saveCallback.result)
         assertNull(saveCallback.error)
-        val resultPerson = saveCallback.result?.entities?.get(0) as Person
+        val resultPerson = saveCallback.result!!
         assertNotNull(resultPerson.id)
         assertEquals(person.username, resultPerson.username)
     }
@@ -169,19 +167,23 @@ class DataStoreSingleInsertTest : BaseDataStoreMultiInsertTest() {
         val saveCallback = create(personStore, person)
         assertNull(saveCallback.error)
         assertNotNull(saveCallback.result)
-        assertNotNull(saveCallback.result!!.entities)
         if (storeType == StoreType.SYNC) {
-            Assert.assertTrue(saveCallback.result!!.entities?.get(0)?.id?.startsWith("temp")!!)
+            Assert.assertTrue(saveCallback.result!!.id?.startsWith("temp")!!)
             val pushCallback = push(personStore, DEFAULT_TIMEOUT)
             assertNull(pushCallback.error)
             assertNotNull(pushCallback.result)
         } else {
-            Assert.assertTrue(saveCallback.result!!.entities?.get(0)?.id?.startsWith("temp")!!)
+            Assert.assertTrue(!saveCallback.result!!.id?.startsWith("temp")!!)
         }
         val findCallback = find(personStore, LONG_TIMEOUT)
         assertNotNull(findCallback.result)
         assertNotNull(findCallback.result!!.result)
-        Assert.assertTrue(!saveCallback.result!!.entities?.get(0)?.id?.startsWith("temp")!!)
+        if (storeType == StoreType.SYNC) {
+            Assert.assertTrue(saveCallback.result!!.id?.startsWith("temp")!!)
+        } else {
+            Assert.assertTrue(!saveCallback.result!!.id?.startsWith("temp")!!)
+        }
+
     }
 
     @Test

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreSingleInsertTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreSingleInsertTest.kt
@@ -219,5 +219,12 @@ class DataStoreSingleInsertTest : BaseDataStoreMultiInsertTest() {
         assertNotNull(saveCallback.result?.errors)
         assertNotNull(saveCallback.result?.errors?.get(0)?.description)
         assertNotNull(saveCallback.result?.errors?.get(0)?.debug)
+        assertEquals(saveCallback.result?.errors?.get(0)?.description, ERROR_DESCRIPTION)
+        assertEquals(saveCallback.result?.errors?.get(0)?.debug, ERROR_DEBUG)
+    }
+
+    companion object {
+        const val ERROR_DEBUG = "An entity with that _id already exists in this collection"
+        const val ERROR_DESCRIPTION = "The Kinvey server encountered an unexpected error. Please retry your request."
     }
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/UserStoreTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/user/UserStoreTest.kt
@@ -702,7 +702,7 @@ class UserStoreTest {
 
     @Test
     @Throws(RuntimeException::class)
-    fun loginKinveyAuthError() {
+    fun loginKinveyAuthErrorDeprecated() {
         var isExceptionThrown = false
         val latch = CountDownLatch(1)
         val looperThread: LooperThread
@@ -731,7 +731,7 @@ class UserStoreTest {
 
     @Test
     @Throws(RuntimeException::class)
-    fun LoginKinveyAuthError() {
+    fun loginKinveyAuthError() {
         var isExceptionThrown = false
         val latch = CountDownLatch(1)
         val looperThread: LooperThread

--- a/android-lib/src/main/java/com/kinvey/android/async/AsyncCreateRequest.kt
+++ b/android-lib/src/main/java/com/kinvey/android/async/AsyncCreateRequest.kt
@@ -8,11 +8,11 @@ import com.kinvey.java.core.KinveyClientCallback
 import com.kinvey.java.model.KinveySaveBatchResponse
 import java.io.IOException
 
-class AsyncCreateRequest<T: GenericJson>(val store: DataStore<T>, var entity: T, callback: KinveyClientCallback<KinveySaveBatchResponse<T>>?)
-    : AsyncClientRequest<KinveySaveBatchResponse<T>>(callback) {
+class AsyncCreateRequest<T: GenericJson>(val store: DataStore<T>, var entity: T, callback: KinveyClientCallback<T>)
+    : AsyncClientRequest<T>(callback) {
 
     @Throws(IOException::class)
-    override fun executeAsync(): KinveySaveBatchResponse<T> {
+    override fun executeAsync(): T? {
         Logger.INFO("Calling CreateRequest#executeAsync()")
         return store.create(entity)
     }

--- a/android-lib/src/main/java/com/kinvey/android/async/AsyncCreateRequest.kt
+++ b/android-lib/src/main/java/com/kinvey/android/async/AsyncCreateRequest.kt
@@ -1,0 +1,19 @@
+package com.kinvey.android.async
+
+import com.google.api.client.json.GenericJson
+import com.kinvey.android.AsyncClientRequest
+import com.kinvey.android.store.DataStore
+import com.kinvey.java.Logger
+import com.kinvey.java.core.KinveyClientCallback
+import com.kinvey.java.model.KinveySaveBatchResponse
+import java.io.IOException
+
+class AsyncCreateRequest<T: GenericJson>(val store: DataStore<T>, var entity: T, callback: KinveyClientCallback<KinveySaveBatchResponse<T>>?)
+    : AsyncClientRequest<KinveySaveBatchResponse<T>>(callback) {
+
+    @Throws(IOException::class)
+    override fun executeAsync(): KinveySaveBatchResponse<T> {
+        Logger.INFO("Calling CreateRequest#executeAsync()")
+        return store.create(entity)
+    }
+}

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
@@ -444,7 +444,6 @@ open class DataStore<T : GenericJson> : BaseDataStore<T> {
         Preconditions.checkNotNull(client, "client must not be null")
         Preconditions.checkArgument(client?.isInitialize ?: false, "client must be initialized.")
         Preconditions.checkNotNull(entity, "Entity cannot be null.")
-        Preconditions.checkState(kinveyApiVersion >= KINVEY_API_VERSION_5, "Kinvey api version cannot be less than 5.")
         Logger.INFO("Calling DataStore#create(entity)")
         AsyncCreateRequest(this, entity, callback).execute()
     }

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
@@ -18,12 +18,9 @@ package com.kinvey.android.store
 import com.google.api.client.json.GenericJson
 import com.google.common.base.Preconditions
 import com.kinvey.android.AsyncClientRequest
-import com.kinvey.android.async.AsyncBatchPushRequest
-import com.kinvey.android.async.AsyncPullRequest
 import com.kinvey.android.KinveyCallbackHandler
 import com.kinvey.android.KinveyLiveServiceCallbackHandler
-import com.kinvey.android.async.AsyncPushRequest
-import com.kinvey.android.async.AsyncRequest
+import com.kinvey.android.async.*
 import com.kinvey.android.callback.KinveyCountCallback
 import com.kinvey.android.callback.KinveyDeleteCallback
 import com.kinvey.android.callback.KinveyReadCallback
@@ -46,6 +43,7 @@ import com.kinvey.java.store.BaseDataStore
 import com.kinvey.java.store.KinveyDataStoreLiveServiceCallback
 import com.kinvey.java.store.KinveyLiveServiceStatus
 import com.kinvey.java.store.StoreType
+import com.kinvey.java.store.requests.data.save.CreateRequest
 
 import java.io.IOException
 import java.lang.reflect.Method
@@ -416,6 +414,39 @@ open class DataStore<T : GenericJson> : BaseDataStore<T> {
     </T> */
     fun create(entities: List<T>, callback: KinveyClientCallback<KinveySaveBatchResponse<T>>) {
         createBatch(entities, callback)
+    }
+
+    /**
+     * Asynchronous request to create an entity to a collection.
+     *
+     *
+     * Constructs an asynchronous request to create an entity <T> to a collection.
+     * Creates the entity if it doesn't exist, return error in error list of response for entity if it does exist.
+     * If an "_id" property is not present, the Kinvey backend will generate one.
+    </T> *
+     *
+     *
+     * Sample Usage:
+     * <pre>
+     * `DataStore<EventEntity> myAppData = DataStore.collection("myCollection", EventEntity.class, StoreType.SYNC, myClient);
+     * myAppData.create(entity, new KinveyClientCallback<KinveySaveBatchResponse<EventEntity>> {
+     * public void onFailure(Throwable t) { ... }
+     * public void onSuccess(KinveySaveBatchResponse<EventEntity> entity) { ... }
+     * });
+    ` *
+    </pre> *
+     *
+     *
+     * @param entity The entity to create
+     * @param callback KinveyClientCallback<KinveySaveBatchResponse<T>>
+    </T> */
+    fun create(entity: T, callback: KinveyClientCallback<KinveySaveBatchResponse<T>>) {
+        Preconditions.checkNotNull(client, "client must not be null")
+        Preconditions.checkArgument(client?.isInitialize ?: false, "client must be initialized.")
+        Preconditions.checkNotNull(entity, "Entity cannot be null.")
+        Preconditions.checkState(kinveyApiVersion >= KINVEY_API_VERSION_5, "Kinvey api version cannot be less than 5.")
+        Logger.INFO("Calling DataStore#create(entity)")
+        AsyncCreateRequest(this, entity, callback).execute()
     }
 
     private fun createBatch(entities: List<T>, callback: KinveyClientCallback<KinveySaveBatchResponse<T>>) {

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
@@ -421,7 +421,7 @@ open class DataStore<T : GenericJson> : BaseDataStore<T> {
      *
      *
      * Constructs an asynchronous request to create an entity <T> to a collection.
-     * Creates the entity if it doesn't exist, return error in error list of response for entity if it does exist.
+     * Creates the entity if it doesn't exist, return error for entity if it does exist.
      * If an "_id" property is not present, the Kinvey backend will generate one.
     </T> *
      *
@@ -429,18 +429,18 @@ open class DataStore<T : GenericJson> : BaseDataStore<T> {
      * Sample Usage:
      * <pre>
      * `DataStore<EventEntity> myAppData = DataStore.collection("myCollection", EventEntity.class, StoreType.SYNC, myClient);
-     * myAppData.create(entity, new KinveyClientCallback<KinveySaveBatchResponse<EventEntity>> {
+     * myAppData.create(entity, new KinveyClientCallback<EventEntity> {
      * public void onFailure(Throwable t) { ... }
-     * public void onSuccess(KinveySaveBatchResponse<EventEntity> entity) { ... }
+     * public void onSuccess(EventEntity entity) { ... }
      * });
     ` *
     </pre> *
      *
      *
      * @param entity The entity to create
-     * @param callback KinveyClientCallback<KinveySaveBatchResponse<T>>
+     * @param callback KinveyClientCallback<T>
     </T> */
-    fun create(entity: T, callback: KinveyClientCallback<KinveySaveBatchResponse<T>>) {
+    fun create(entity: T, callback: KinveyClientCallback<T>) {
         Preconditions.checkNotNull(client, "client must not be null")
         Preconditions.checkArgument(client?.isInitialize ?: false, "client must be initialized.")
         Preconditions.checkNotNull(entity, "Entity cannot be null.")

--- a/java-api-core/src/com/kinvey/java/network/NetworkManager.kt
+++ b/java-api-core/src/com/kinvey/java/network/NetworkManager.kt
@@ -947,7 +947,7 @@ open class NetworkManager<T : GenericJson>(
     class Create<T : GenericJson>(networkManager: NetworkManager<T>, client : AbstractClient<*>?, item: T?,
                     responseClassType: Class<KinveySaveBatchResponse<T>>, parClassType: Class<T>?, update: SaveMode?)
         : KinveyJsonStringClientRequest<KinveySaveBatchResponse<T>>(client, update.toString(), SAVE_BATCH_REST_PATH,
-            item.toString(), responseClassType, parClassType) {
+            Gson().toJson(item), responseClassType, parClassType) {
         @Key
         var collectionName: String? = networkManager.collectionName
 

--- a/java-api-core/src/com/kinvey/java/network/NetworkManager.kt
+++ b/java-api-core/src/com/kinvey/java/network/NetworkManager.kt
@@ -432,8 +432,7 @@ open class NetworkManager<T : GenericJson>(
 
     @Throws(IOException::class)
     open fun createBlocking(entity: T?): Create<T>? {
-        val responseClassType = KinveySaveBatchResponse::class.java
-        val create = Create(this, client, entity, responseClassType as Class<KinveySaveBatchResponse<T>>, currentClass, SaveMode.POST)
+        val create = Create(this, client, entity, currentClass!!, currentClass, SaveMode.POST)
         client?.initializeRequest(create)
         return create
     }
@@ -945,8 +944,8 @@ open class NetworkManager<T : GenericJson>(
      *
      */
     class Create<T : GenericJson>(networkManager: NetworkManager<T>, client : AbstractClient<*>?, item: T?,
-                    responseClassType: Class<KinveySaveBatchResponse<T>>, parClassType: Class<T>?, update: SaveMode?)
-        : KinveyJsonStringClientRequest<KinveySaveBatchResponse<T>>(client, update.toString(), SAVE_BATCH_REST_PATH,
+                    responseClassType: Class<T>, parClassType: Class<T>?, update: SaveMode?)
+        : KinveyJsonStringClientRequest<T>(client, update.toString(), SAVE_BATCH_REST_PATH,
             Gson().toJson(item), responseClassType, parClassType) {
         @Key
         var collectionName: String? = networkManager.collectionName

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.kt
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.kt
@@ -27,6 +27,7 @@ import com.kinvey.java.Query
 import com.kinvey.java.cache.ICache
 import com.kinvey.java.cache.KinveyCachedClientCallback
 import com.kinvey.java.core.KinveyCachedAggregateCallback
+import com.kinvey.java.core.KinveyClientCallback
 import com.kinvey.java.core.KinveyJsonResponseException
 import com.kinvey.java.model.*
 import com.kinvey.java.network.NetworkManager
@@ -316,7 +317,7 @@ open class BaseDataStore<T : GenericJson> @JvmOverloads protected constructor(
      * @throws IOException
      */
     @Throws(IOException::class)
-    fun create(`object`: T): KinveySaveBatchResponse<T> {
+    fun create(`object`: T): T? {
         Preconditions.checkNotNull(client, "client must not be null.")
         Preconditions.checkArgument(client?.isInitialize ?: false, "client must be initialized.")
         Preconditions.checkNotNull(`object`, "object must not be null.")

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.kt
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.kt
@@ -41,10 +41,7 @@ import com.kinvey.java.store.requests.data.read.ReadCountRequest
 import com.kinvey.java.store.requests.data.read.ReadIdsRequest
 import com.kinvey.java.store.requests.data.read.ReadQueryRequest
 import com.kinvey.java.store.requests.data.read.ReadSingleRequest
-import com.kinvey.java.store.requests.data.save.CreateListBatchRequest
-import com.kinvey.java.store.requests.data.save.SaveListBatchRequest
-import com.kinvey.java.store.requests.data.save.SaveListRequest
-import com.kinvey.java.store.requests.data.save.SaveRequest
+import com.kinvey.java.store.requests.data.save.*
 
 import java.io.IOException
 import java.security.AccessControlException
@@ -310,6 +307,21 @@ open class BaseDataStore<T : GenericJson> @JvmOverloads protected constructor(
         Preconditions.checkNotNull(objects, "objects must not be null.")
         Logger.INFO("Calling BaseDataStore#createBatch(listObjects)")
         return CreateListBatchRequest(cache, networkManager, this.storeType.writePolicy, objects, client?.syncManager).execute()
+    }
+
+    /**
+     * create object for collections
+     * @param object object to be created
+     * @return object with list of successful created entities and with list of errors
+     * @throws IOException
+     */
+    @Throws(IOException::class)
+    fun create(`object`: T): KinveySaveBatchResponse<T> {
+        Preconditions.checkNotNull(client, "client must not be null.")
+        Preconditions.checkArgument(client?.isInitialize ?: false, "client must be initialized.")
+        Preconditions.checkNotNull(`object`, "object must not be null.")
+        Logger.INFO("Calling BaseDataStore#create(item)")
+        return CreateRequest(cache, networkManager, this.storeType.writePolicy, `object`, client?.syncManager).execute()
     }
 
     /**

--- a/java-api-core/src/com/kinvey/java/store/requests/data/save/CreateRequest.kt
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/save/CreateRequest.kt
@@ -1,0 +1,193 @@
+/*
+ *  Copyright (c) 2020, Kinvey, Inc. All rights reserved.
+ *
+ * This software is licensed to you under the Kinvey terms of service located at
+ * http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+ * software, you hereby accept such terms of service  (and any agreement referenced
+ * therein) and agree that you have read, understand and agree to be bound by such
+ * terms of service and are of legal age to agree to such terms with Kinvey.
+ *
+ * This software contains valuable confidential and proprietary information of
+ * KINVEY, INC and is subject to applicable licensing agreements.
+ * Unauthorized reproduction, transmission or distribution of this file and its
+ * contents is a violation of applicable laws.
+ *
+ */
+
+package com.kinvey.java.store.requests.data.save
+
+import com.google.api.client.http.HttpResponseException
+import com.google.api.client.json.GenericJson
+import com.kinvey.java.KinveySaveBatchException
+import com.kinvey.java.Logger
+import com.kinvey.java.cache.ICache
+import com.kinvey.java.core.KinveyJsonResponseException
+import com.kinvey.java.model.KinveyBatchInsertError
+import com.kinvey.java.model.KinveySaveBatchResponse
+import com.kinvey.java.network.NetworkManager
+import com.kinvey.java.store.WritePolicy
+import com.kinvey.java.store.requests.data.IRequest
+import com.kinvey.java.store.requests.data.PushBatchRequest
+import com.kinvey.java.sync.SyncManager
+import com.kinvey.java.sync.dto.SyncRequest
+
+import java.io.IOException
+
+import com.kinvey.java.Constants._ID
+
+class CreateRequest<T : GenericJson>(
+        private val cache: ICache<T>?,
+        private val networkManager: NetworkManager<T>,
+        private val writePolicy: WritePolicy,
+        private val entity: T,
+        private val syncManager: SyncManager?) : IRequest<KinveySaveBatchResponse<T>> {
+
+    private var exception: IOException? = null
+    private var wasException = false
+
+    @Throws(IOException::class)
+    override fun execute(): KinveySaveBatchResponse<T>  {
+        var res = KinveySaveBatchResponse<T>()
+        when (writePolicy) {
+            WritePolicy.FORCE_LOCAL -> {
+                val ret: T? = cache?.save(entity)
+                ret?.let {
+                    syncManager?.enqueueSaveRequests(networkManager.collectionName
+                            ?: "", networkManager, listOf(ret))
+                    res.entities = mutableListOf(ret)
+                }
+            }
+            WritePolicy.LOCAL_THEN_NETWORK -> {
+                doPushRequest()
+                val itemsToSend = cache?.save(entity)
+                res = runSaveItemsRequest(itemsToSend)
+                if (exception is IOException) {
+                    throw IOException(exception)
+                }
+            }
+            WritePolicy.FORCE_NETWORK -> {
+                res = runSaveItemsRequest(entity, false)
+                if (exception is IOException) {
+                    throw IOException(exception)
+                }
+            }
+        }
+        return res
+    }
+
+    @Throws(IOException::class)
+    private fun runSaveItemsRequest(entity: T?, useCache: Boolean = true): KinveySaveBatchResponse<T> {
+        Logger.INFO("Start saving entities")
+        val res: KinveySaveBatchResponse<T> = KinveySaveBatchResponse()
+        if (entity != null) {
+            postCreateRequest(entity, res, useCache)
+        }
+        if (wasException && exception == null) {
+            exception = KinveySaveBatchException(null, null, null)
+        }
+        Logger.INFO("Finish saving entities")
+        return res
+    }
+
+    @Throws(IOException::class)
+    private fun postCreateRequest(entity: T,
+                                     result: KinveySaveBatchResponse<T>, useCache: Boolean = true): KinveySaveBatchResponse<T>? {
+        var response: KinveySaveBatchResponse<T>? = null
+        var tempIds: String? = null
+        if (useCache) tempIds = if (networkManager.isTempId(entity)) entity[_ID] as String  else null
+        try {
+            response = if (useCache && !tempIds.isNullOrEmpty()) {
+                val entityWithoutId = if (networkManager.isTempId(entity)) {
+                    entity.set(_ID, null) as T
+                } else {
+                    entity
+                }
+                networkManager.createBlocking(entityWithoutId)?.execute()
+            } else {
+                networkManager.createBlocking(entity)?.execute()
+            }
+        } catch (e: KinveyJsonResponseException) {
+            throw e
+        } catch (e: IOException) {
+            if (!useCache || (e is HttpResponseException && e.statusCode == 401)) {
+                wasException = true
+                exception = e
+            }
+            if (useCache) { enqueueSaveRequest(entity, SyncRequest.HttpVerb.POST) }
+        }
+        if (response != null) {
+            if (response.entities != null) {
+                if (result.entities == null) {
+                    result.entities = mutableListOf()
+                }
+                result.entities!!.addAll(response.entities!!)
+                // If object does not have an _id, then it is being created locally. The cache may
+                // provide an _id in this case, but before it is saved to the network, this temporary
+                // _id should be removed prior to saving to the backend. This way, the backend
+                // will generate a permanent _id that will be used by the cache. Once we get the
+                // result from the backend with the permanent _id, the record in the cache with the
+                // temporary _id should be removed, and the new record should be saved.
+                if (useCache && !tempIds.isNullOrEmpty()) {
+                    // The result from the network has the entity with its permanent ID. Need
+                    // to remove the entity from the local cache with the temporary ID.
+                    cache?.delete(tempIds)
+                    cache?.save(response.entities)
+                }
+            }
+            if (response.errors != null) {
+                if (result.errors == null) {
+                    result.errors = mutableListOf()
+                }
+                result.errors!!.addAll(response.errors!!)
+            }
+            if (response.haveErrors && useCache) {
+               enqueueErrorRequest(entity, response)
+            }
+            if (response.haveErrors) {
+                removeSuccessItemFromCache(entity, response.errors!![0])
+            }
+
+        }
+        return response
+    }
+
+    @Throws(IOException::class)
+    private fun enqueueErrorRequest(saveItem: T, response: KinveySaveBatchResponse<*>) {
+        if (response.haveErrors) {
+            enqueueSaveRequest(saveItem, SyncRequest.HttpVerb.POST)
+        }
+    }
+
+    @Throws(IOException::class)
+    private fun enqueueSaveRequest(errorItem: T, requestType: SyncRequest.HttpVerb) {
+        syncManager?.enqueueRequest(networkManager.collectionName, networkManager, requestType, errorItem[_ID] as String?)
+    }
+
+    private fun doPushRequest() {
+        val pushRequest = PushBatchRequest(networkManager.collectionName ?: "",
+                cache as ICache<T>, networkManager, networkManager.client)
+        try {
+            pushRequest.execute()
+        } catch (t: Throwable) {
+            Logger.ERROR(t.message)
+        }
+    }
+
+    private fun removeSuccessItemFromCache(saveItem: T, error: KinveyBatchInsertError?) {
+        if (cache != null && error != null) {
+            removeFromCache(saveItem)
+        }
+    }
+
+    private fun removeFromCache(item: T): String {
+        var itemId = ""
+        cache?.let {
+            itemId = item[_ID]?.toString() ?: ""
+            it.delete(itemId)
+        }
+        return itemId
+    }
+
+    //TODO: put async and track cancel
+    override fun cancel() {}
+}


### PR DESCRIPTION
#### Description
The `create` function should support also a single item.

#### Changes
Added `create(entity: T, callback: KinveyClientCallback<T>)` function to `DataStore` class.

#### Tests
Instrumented.
