### PR TITLE
KDEV-843: Update the default KCS api version to 5

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/request/HeaderTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/request/HeaderTest.kt
@@ -8,13 +8,14 @@ import com.kinvey.android.Client
 import com.kinvey.android.Client.Builder
 import com.kinvey.android.model.User
 import com.kinvey.androidTest.TestManager
+import com.kinvey.java.AbstractClient
 import com.kinvey.java.auth.KinveyAuthRequest
 import com.kinvey.java.core.KinveyHeaders
 import com.kinvey.java.store.UserStoreRequestManager
 import com.kinvey.java.store.UserStoreRequestManager.LoginRequest
-import junit.framework.Assert.assertNotNull
-import junit.framework.Assert.assertTrue
+import junit.framework.Assert.*
 import org.junit.After
+import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -45,6 +46,29 @@ class HeaderTest {
             } catch (throwable: Throwable) {
                 throwable.printStackTrace()
             }
+        }
+    }
+
+    @Test
+    fun kinveyApiVersionDefaultTest() {
+        val headers = KinveyHeaders()
+        var field: Field? = null
+        try {
+            field = KinveyHeaders::class.java.getDeclaredField("kinveyApiVersion")
+        } catch (e: NoSuchFieldException) {
+            e.printStackTrace()
+        }
+        assert(field != null)
+        field?.isAccessible = true
+        var version = "0"
+        try {
+           version =  field?.get(headers) as String
+        } catch (e: IllegalAccessException) {
+            e.printStackTrace()
+        }
+        assertNotEquals(version, "0")
+        if (AbstractClient.kinveyApiVersion.isEmpty()) {
+            assertEquals(version, "5")
         }
     }
 

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.kt
@@ -1192,7 +1192,7 @@ open class DataStore<T : GenericJson> : BaseDataStore<T> {
 
         private const val KINVEY_API_VERSION_5 = 5
 
-        private const val DEFAULT_KINVEY_API_VERSION = 4
+        private const val DEFAULT_KINVEY_API_VERSION = 5
 
         private val KEY_GROUP = "KEY_GROUP"
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ allprojects  {
   group = 'com.kinvey'
   version = '4.3.6'
   description = "The Kinvey SDK makes it easy to write Android apps with Kinvey"
-  ext.kinveyApiVersion = '4'
+  ext.kinveyApiVersion = '5'
   ext.dokkaVersion = '0.9.17'
 }
 


### PR DESCRIPTION
#### Description
The default KCS api version should be `5`

#### Changes
Updated the default KCS api version to `5`

#### Tests
Instrumented.
