### PR TITLE
fix: KDEV-781 Batch create  - SYNC store  - No errors are returned although the creation of some of the items fails

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreMultiInsertTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreMultiInsertTest.kt
@@ -13,6 +13,7 @@ import com.kinvey.java.core.KinveyJsonResponseException
 import com.kinvey.java.store.StoreType
 import com.kinvey.java.sync.dto.SyncRequest
 import com.kinvey.java.AbstractClient.Companion.kinveyApiVersion
+import com.kinvey.java.Constants
 
 
 import org.junit.Ignore
@@ -1530,6 +1531,13 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         assertNotNull(saveCallback.result?.errors)
         assertNotNull(saveCallback.result?.errors?.get(0)?.description)
         assertNotNull(saveCallback.result?.errors?.get(0)?.debug)
+        if (storeType == StoreType.NETWORK) {
+            assertEquals(saveCallback.result?.errors?.get(0)?.description, DataStoreSingleInsertTest.ERROR_DESCRIPTION)
+            assertEquals(saveCallback.result?.errors?.get(0)?.debug, DataStoreSingleInsertTest.ERROR_DEBUG)
+        } else {
+            assertEquals(saveCallback.result?.errors?.get(0)?.description, Constants.SAVE_BATCH_ERROR_DESCRIPTION)
+            assertEquals(saveCallback.result?.errors?.get(0)?.debug, Constants.SAVE_BATCH_ERROR_DEBUG)
+        }
     }
 
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreMultiInsertTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreMultiInsertTest.kt
@@ -60,6 +60,8 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         val saveCallback = createList(personStore, personList)
         assertNull(saveCallback.error)
         assertNotNull(saveCallback.result)
+        assertEquals(saveCallback.result?.errors?.size, 0)
+        assertEquals(saveCallback.result?.entities?.size, 5)
 
         val findCallback = find(personStore, LONG_TIMEOUT)
         assertNotNull(findCallback.result)
@@ -70,10 +72,9 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         val saveCallbackSecond = createList(personStore, personListSecond)
         assertNull(saveCallbackSecond.error)
         assertNotNull(saveCallbackSecond.result)
-        if (!storeType.equals(StoreType.SYNC)) {
-            assertNotNull(saveCallbackSecond.result?.errors)
-            assertEquals(saveCallbackSecond.result?.errors?.size, 5)
-        }
+        assertNotNull(saveCallbackSecond.result?.errors)
+        assertEquals(saveCallbackSecond.result?.errors?.size, 5)
+        assertEquals(saveCallbackSecond.result?.entities?.size, 1)
     }
 
     @Test
@@ -1510,7 +1511,6 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
     }
 
     @Test
-    @Ignore("Should work after fixing: https://kinvey.atlassian.net/browse/KDEV-781")
     @Throws(InterruptedException::class)
     fun testErrorMessageIfSameIdExistsSync() {
         testErrorMessageIfSameIdExists(StoreType.SYNC)

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreSingleInsertTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreSingleInsertTest.kt
@@ -9,6 +9,7 @@ import com.kinvey.androidTest.model.Person
 import com.kinvey.java.core.KinveyJsonResponseException
 import com.kinvey.java.store.StoreType
 import com.kinvey.java.AbstractClient.Companion.kinveyApiVersion
+import com.kinvey.java.Constants
 import com.kinvey.java.Constants._ID
 import org.junit.Assert
 
@@ -199,7 +200,6 @@ class DataStoreSingleInsertTest : BaseDataStoreMultiInsertTest() {
     }
 
     @Test
-    @Ignore("Should work after fixing: https://kinvey.atlassian.net/browse/KDEV-781")
     @Throws(InterruptedException::class)
     fun testErrorMessageIfSameIdExistsSync() {
         testErrorMessageIfSameIdExists(StoreType.SYNC)
@@ -219,8 +219,13 @@ class DataStoreSingleInsertTest : BaseDataStoreMultiInsertTest() {
         assertNotNull(saveCallback.result?.errors)
         assertNotNull(saveCallback.result?.errors?.get(0)?.description)
         assertNotNull(saveCallback.result?.errors?.get(0)?.debug)
-        assertEquals(saveCallback.result?.errors?.get(0)?.description, ERROR_DESCRIPTION)
-        assertEquals(saveCallback.result?.errors?.get(0)?.debug, ERROR_DEBUG)
+        if (storeType == StoreType.NETWORK) {
+            assertEquals(saveCallback.result?.errors?.get(0)?.description, ERROR_DESCRIPTION)
+            assertEquals(saveCallback.result?.errors?.get(0)?.debug, ERROR_DEBUG)
+        } else {
+            assertEquals(saveCallback.result?.errors?.get(0)?.description, Constants.SAVE_BATCH_ERROR_DESCRIPTION)
+            assertEquals(saveCallback.result?.errors?.get(0)?.debug, Constants.SAVE_BATCH_ERROR_DEBUG)
+        }
     }
 
     companion object {

--- a/java-api-core/src/com/kinvey/java/Constants.kt
+++ b/java-api-core/src/com/kinvey/java/Constants.kt
@@ -25,6 +25,9 @@ object Constants {
     const val META_ID = "meta.id"
 
     const val ACCESS_ERROR = "Access Error"
+    const val SAVE_BATCH_ERROR = "KinveyInternalErrorRetry"
+    const val SAVE_BATCH_ERROR_DEBUG = "An entity with that _id already exists in this collection"
+    const val SAVE_BATCH_ERROR_DESCRIPTION = "The Kinvey database encountered an unexpected error. Please retry your request."
 
     const val DELETE = "DELETE"
     const val REQUEST_METHOD = "requestMethod"


### PR DESCRIPTION
#### Description
No errors are returned if use `DataStore.create(entities)` with items which already was created before (the backend\datastore already has items with such ids).

#### Changes
Added checking if items already exist in a local database by ids, if such items exist then SDK returns `KinveyBatchInsertError` with next fields: 
```
error = KinveyInternalErrorRetry
description = The Kinvey database encountered an unexpected error. Please retry your request.
debug = An entity with that _id already exists in this collection
```
Backend returns the same fields in the same case, except `description`. In backend error message user gets  `The Kinvey server encountered an unexpected error. Please retry your request.`. The difference is in words `database` and `server`. I think it's more logically to return error with the word `database` for `StoreType.SYNC`.

Also now in `KinveySaveBatchResponse` if a user tried to create 6 entities and had 5 errors and only 1 success item, he gets 5 errors and 1 entity in `entities`. Before the fix, the user could have 6 entities in success `entities` but 5 of them didn't have `id` or fields was empty or default values and 5 errors. 

#### Tests
Instrumented.
