### PR TITLE
fix: KDEV-957: Not able to create items more than once

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreMultiInsertTest.kt
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/data/multiinsert/DataStoreMultiInsertTest.kt
@@ -1360,9 +1360,36 @@ class DataStoreMultiInsertTest : BaseDataStoreMultiInsertTest() {
         persons2.add(person3)
         persons2.add(person4)
         persons2.add(person5)
-        val badListCallback = createList(autoSync, persons)
+        val badListCallback = createList(autoSync, persons2)
         assertNull(badListCallback.result)
         assertNotNull(badListCallback.error)
+    }
+
+    @Test
+    @Throws(InterruptedException::class)
+    fun testCreateAuto() {
+        val person1 = createPerson(TEST_USERNAME)
+        val person2 = createPerson(TEST_USERNAME)
+        person2[_ID] = "123"
+        val persons = arrayListOf<Person>()
+        persons.add(person1)
+        persons.add(person2)
+        val autoSync = DataStore.collection(MULTI_INSERT_COLLECTION, Person::class.java, StoreType.AUTO, client)
+        clearBackend(autoSync)
+        autoSync.clear()
+        client.syncManager.clear(MULTI_INSERT_COLLECTION)
+        val createListCallback = createList(autoSync, persons)
+        assertNotNull(createListCallback.result)
+        val person3 = createPerson(TEST_USERNAME)
+        val person4 = createPerson(TEST_USERNAME)
+        val person5 = createPerson(TEST_USERNAME)
+        val persons2 = arrayListOf<Person>()
+        persons2.add(person3)
+        persons2.add(person4)
+        persons2.add(person5)
+        val secondListCallback = createList(autoSync, persons2)
+        assertNotNull(secondListCallback.result)
+        assertNull(secondListCallback.error)
     }
 
     @Test

--- a/java-api-core/src/com/kinvey/java/store/requests/data/save/CreateListBatchRequest.kt
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/save/CreateListBatchRequest.kt
@@ -97,11 +97,13 @@ class CreateListBatchRequest<T : GenericJson>(
         }
         //items already in the cache
 
-        val itemsInCache = cache?.get(ids) ?: mutableListOf()
-        if (itemsInCache.isNotEmpty()) {
-            val idsInCache = itemsInCache.map { it[_ID] as String }
-            val kinveyException = KinveyException("An entity with _id $idsInCache already exists.")
-            throw kinveyException
+        if (ids.isNotEmpty()) {
+            val itemsInCache = cache?.get(ids) ?: mutableListOf()
+            if (itemsInCache.isNotEmpty()) {
+                val idsInCache = itemsInCache.map { it[_ID] as String }
+                val kinveyException = KinveyException("An entity with _id $idsInCache already exists.")
+                throw kinveyException
+            }
         }
         val retList: List<T> = cache?.save(objects) ?: ArrayList()
 


### PR DESCRIPTION
#### Description
The create operation fails with error `An entity with _id ...` if create several data items, using the new 'create' function and an 'Auto' store and then try to create another several data items, using the new 'create' function and an 'Auto' store.

#### Changes
Added additional checking before searching items with ID in local storage.

#### Tests
Instrumented.
